### PR TITLE
Feature/roi clip for surface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6082,9 +6082,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "inquirer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8418,9 +8418,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-libs-browser": {
@@ -10135,12 +10135,12 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/src/MeshVolume.js
+++ b/src/MeshVolume.js
@@ -77,6 +77,7 @@ export default class MeshVolume {
 
   setRotation(eulerXYZ) {
     this.meshPivot.rotation.copy(eulerXYZ);
+    this.updateClipFromBounds();
   }
 
   setResolution(x, y) {}
@@ -197,6 +198,9 @@ export default class MeshVolume {
     const xmax = this.bounds.bmax.x;
     const ymax = this.bounds.bmax.y;
     const zmax = this.bounds.bmax.z;
+
+    const euler = this.meshPivot.rotation;
+
     // assuming these are 0..1
     for (let channel = 0; channel < this.meshrep.length; ++channel) {
       if (!this.meshrep[channel]) {
@@ -205,22 +209,22 @@ export default class MeshVolume {
       const planes = [];
       // up to 6 planes.
       if (xmin > -0.5) {
-        planes.push(new Plane(new Vector3(1, 0, 0), this.meshRoot.position.x + -xmin * this.scale.x));
+        planes.push(new Plane(new Vector3(1, 0, 0).applyEuler(euler), this.meshRoot.position.x + -xmin * this.scale.x));
       }
       if (ymin > -0.5) {
-        planes.push(new Plane(new Vector3(0, 1, 0), this.meshRoot.position.y + -ymin * this.scale.y));
+        planes.push(new Plane(new Vector3(0, 1, 0).applyEuler(euler), this.meshRoot.position.y + -ymin * this.scale.y));
       }
       if (zmin > -0.5) {
-        planes.push(new Plane(new Vector3(0, 0, 1), this.meshRoot.position.z + -zmin * this.scale.z));
+        planes.push(new Plane(new Vector3(0, 0, 1).applyEuler(euler), this.meshRoot.position.z + -zmin * this.scale.z));
       }
       if (xmax < 0.5) {
-        planes.push(new Plane(new Vector3(-1, 0, 0), this.meshRoot.position.x + xmax * this.scale.x));
+        planes.push(new Plane(new Vector3(-1, 0, 0).applyEuler(euler), this.meshRoot.position.x + xmax * this.scale.x));
       }
       if (ymax < 0.5) {
-        planes.push(new Plane(new Vector3(0, -1, 0), this.meshRoot.position.y + ymax * this.scale.y));
+        planes.push(new Plane(new Vector3(0, -1, 0).applyEuler(euler), this.meshRoot.position.y + ymax * this.scale.y));
       }
       if (zmax < 0.5) {
-        planes.push(new Plane(new Vector3(0, 0, -1), this.meshRoot.position.z + zmax * this.scale.z));
+        planes.push(new Plane(new Vector3(0, 0, -1).applyEuler(euler), this.meshRoot.position.z + zmax * this.scale.z));
       }
       this.meshrep[channel].traverse(function(child) {
         if (child instanceof Mesh) {

--- a/src/MeshVolume.js
+++ b/src/MeshVolume.js
@@ -183,6 +183,8 @@ export default class MeshVolume {
   }
 
   updateClipRegion(xmin, xmax, ymin, ymax, zmin, zmax) {
+    // incoming values expected to be between 0 and 1.
+    // I shift them here to be between -0.5 and 0.5
     this.bounds = {
       bmin: new Vector3(xmin - 0.5, ymin - 0.5, zmin - 0.5),
       bmax: new Vector3(xmax - 0.5, ymax - 0.5, zmax - 0.5),
@@ -200,7 +202,6 @@ export default class MeshVolume {
 
     const euler = this.meshPivot.rotation;
 
-    // assuming these are 0..1
     for (let channel = 0; channel < this.meshrep.length; ++channel) {
       if (!this.meshrep[channel]) {
         continue;

--- a/src/MeshVolume.js
+++ b/src/MeshVolume.js
@@ -26,6 +26,11 @@ export default class MeshVolume {
     this.meshPivot.add(this.meshRoot);
 
     this.meshrep = [];
+
+    this.bounds = {
+      bmin: new Vector3(-0.5, -0.5, -0.5),
+      bmax: new Vector3(0.5, 0.5, 0.5),
+    };
   }
 
   cleanup() {
@@ -78,7 +83,12 @@ export default class MeshVolume {
 
   setOrthoThickness(value) {}
 
-  setAxisClip(axis, minval, maxval, isOrthoAxis) {}
+  setAxisClip(axis, minval, maxval, isOrthoAxis) {
+    console.log("setAxisClip called");
+    this.bounds.bmax[axis] = maxval;
+    this.bounds.bmin[axis] = minval;
+    this.updateClipFromBounds();
+  }
 
   //////////////////////////////
 
@@ -173,6 +183,20 @@ export default class MeshVolume {
   }
 
   updateClipRegion(xmin, xmax, ymin, ymax, zmin, zmax) {
+    this.bounds = {
+      bmin: new Vector3(xmin - 0.5, ymin - 0.5, zmin - 0.5),
+      bmax: new Vector3(xmax - 0.5, ymax - 0.5, zmax - 0.5),
+    };
+    this.updateClipFromBounds();
+  }
+
+  updateClipFromBounds() {
+    const xmin = this.bounds.bmin.x;
+    const ymin = this.bounds.bmin.y;
+    const zmin = this.bounds.bmin.z;
+    const xmax = this.bounds.bmax.x;
+    const ymax = this.bounds.bmax.y;
+    const zmax = this.bounds.bmax.z;
     // assuming these are 0..1
     for (let channel = 0; channel < this.meshrep.length; ++channel) {
       if (!this.meshrep[channel]) {
@@ -180,23 +204,23 @@ export default class MeshVolume {
       }
       const planes = [];
       // up to 6 planes.
-      if (xmin > 0) {
-        planes.push(new Plane(new Vector3(1, 0, 0), this.meshRoot.position.x + (0.5 - xmin) * this.scale.x));
+      if (xmin > -0.5) {
+        planes.push(new Plane(new Vector3(1, 0, 0), this.meshRoot.position.x + -xmin * this.scale.x));
       }
-      if (ymin > 0) {
-        planes.push(new Plane(new Vector3(0, 1, 0), this.meshRoot.position.y + (0.5 - ymin) * this.scale.y));
+      if (ymin > -0.5) {
+        planes.push(new Plane(new Vector3(0, 1, 0), this.meshRoot.position.y + -ymin * this.scale.y));
       }
-      if (zmin > 0) {
-        planes.push(new Plane(new Vector3(0, 0, 1), this.meshRoot.position.z + (0.5 - zmin) * this.scale.z));
+      if (zmin > -0.5) {
+        planes.push(new Plane(new Vector3(0, 0, 1), this.meshRoot.position.z + -zmin * this.scale.z));
       }
-      if (xmax < 1) {
-        planes.push(new Plane(new Vector3(-1, 0, 0), this.meshRoot.position.x + (xmax - 0.5) * this.scale.x));
+      if (xmax < 0.5) {
+        planes.push(new Plane(new Vector3(-1, 0, 0), this.meshRoot.position.x + xmax * this.scale.x));
       }
-      if (ymax < 1) {
-        planes.push(new Plane(new Vector3(0, -1, 0), this.meshRoot.position.y + (ymax - 0.5) * this.scale.y));
+      if (ymax < 0.5) {
+        planes.push(new Plane(new Vector3(0, -1, 0), this.meshRoot.position.y + ymax * this.scale.y));
       }
-      if (zmax < 1) {
-        planes.push(new Plane(new Vector3(0, 0, -1), this.meshRoot.position.z + (zmax - 0.5) * this.scale.z));
+      if (zmax < 0.5) {
+        planes.push(new Plane(new Vector3(0, 0, -1), this.meshRoot.position.z + zmax * this.scale.z));
       }
       this.meshrep[channel].traverse(function(child) {
         if (child instanceof Mesh) {

--- a/src/MeshVolume.js
+++ b/src/MeshVolume.js
@@ -85,7 +85,6 @@ export default class MeshVolume {
   setOrthoThickness(value) {}
 
   setAxisClip(axis, minval, maxval, isOrthoAxis) {
-    console.log("setAxisClip called");
     this.bounds.bmax[axis] = maxval;
     this.bounds.bmin[axis] = minval;
     this.updateClipFromBounds();

--- a/src/ThreeJsPanel.js
+++ b/src/ThreeJsPanel.js
@@ -67,7 +67,6 @@ export class ThreeJsPanel {
         // set pixel ratio to 0.25 or 0.5 to render at lower res.
         this.renderer.setPixelRatio(window.devicePixelRatio);
         this.renderer.state.setBlending(NormalBlending);
-        this.renderer.localClippingEnabled = true;
         //required by WebGL 2.0 for rendering to FLOAT textures
         this.renderer.getContext().getExtension("EXT_color_buffer_float");
       }
@@ -83,6 +82,7 @@ export class ThreeJsPanel {
       this.renderer.setPixelRatio(window.devicePixelRatio);
       this.renderer.state.setBlending(NormalBlending);
     }
+    this.renderer.localClippingEnabled = true;
     this.renderer.setSize(parentElement.offsetWidth, parentElement.offsetHeight);
 
     this.timer = new Timing();

--- a/src/ThreeJsPanel.js
+++ b/src/ThreeJsPanel.js
@@ -67,6 +67,7 @@ export class ThreeJsPanel {
         // set pixel ratio to 0.25 or 0.5 to render at lower res.
         this.renderer.setPixelRatio(window.devicePixelRatio);
         this.renderer.state.setBlending(NormalBlending);
+        this.renderer.localClippingEnabled = true;
         //required by WebGL 2.0 for rendering to FLOAT textures
         this.renderer.getContext().getExtension("EXT_color_buffer_float");
       }

--- a/src/VolumeDrawable.js
+++ b/src/VolumeDrawable.js
@@ -507,6 +507,7 @@ export default class VolumeDrawable {
 
   updateClipRegion(xmin, xmax, ymin, ymax, zmin, zmax) {
     this.volumeRendering.updateClipRegion(xmin, xmax, ymin, ymax, zmin, zmax);
+    this.meshVolume.updateClipRegion(xmin, xmax, ymin, ymax, zmin, zmax);
   }
 
   updateLights(state) {


### PR DESCRIPTION
Volume-viewer supports axis-aligned clipping regions, but until now it has never been implemented for isosurface meshes.

This code change uses threejs's built-in clip plane support to orient the clipping regions for isosurface meshes so they are matched up with those used in volume rendering.