### PR TITLE
Update threejs version and fix isosurface color bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11266,9 +11266,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.112.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.112.1.tgz",
-      "integrity": "sha512-8I0O74hiYtKl3LgDNcPJbBGOlpekbcJ6fJnImmW3mFdeUFJ2H9Y3/UuUSW2sBdjrIlCM0gvOkaTEFlofO900TQ=="
+      "version": "0.126.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.126.1.tgz",
+      "integrity": "sha512-eOEXnZeE1FDV0XgL1u08auIP13jxdN9LQBAEmlErYzMxtIIfuGIAZbijOyookALUhqVzVOx0Tywj6n192VM+nQ=="
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "access": "public"
   },
   "dependencies": {
-    "three": "^0.112.1"
+    "three": "^0.126.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.11.6",

--- a/src/NaiveSurfaceNets.js
+++ b/src/NaiveSurfaceNets.js
@@ -31,7 +31,7 @@
  */
 
 // MODIFIED 2018 BY DANIELT@ALLENINSTITUTE.ORG TO ACCEPT AN ISOVALUE AND RESCALE VERTEX POSITIONS
-import { BufferGeometry } from "three";
+import { BufferAttribute, BufferGeometry } from "three";
 var SurfaceNets = (function() {
   "use strict";
 
@@ -202,7 +202,9 @@ function ConstructTHREEGeometry(surfaceNetResult) {
   var varray = new Float32Array(result.vertices.length * 3);
   for (var i = 0; i < result.vertices.length; ++i) {
     var v = result.vertices[i];
-    varray.push(v[0], v[1], v[2]);
+    varray[i * 3 + 0] = v[0];
+    varray[i * 3 + 1] = v[1];
+    varray[i * 3 + 2] = v[2];
   }
 
   // count triangles; split quad faces
@@ -221,20 +223,28 @@ function ConstructTHREEGeometry(surfaceNetResult) {
 
   var inds = new Uint32Array(n_triangles * 3);
 
+  let j = 0;
   for (var i = 0; i < result.faces.length; ++i) {
     var f = result.faces[i];
     // note what appears to be inverted winding order.
     // I believe this is related to isosurface < or > testing but have not checked.
     if (f.length === 3) {
-      inds.push(f[2], f[1], f[0]);
+      inds[j++] = f[2];
+      inds[j++] = f[1];
+      inds[j++] = f[0];
     } else if (f.length === 4) {
-      inds.push(f[2], f[1], f[0]);
-      inds.push(f[3], f[2], f[0]);
+      // two triangles: (2,1,0) and (3,2,0)
+      inds[j++] = f[2];
+      inds[j++] = f[1];
+      inds[j++] = f[0];
+      inds[j++] = f[3];
+      inds[j++] = f[2];
+      inds[j++] = f[0];
     }
   }
 
   var geo = new BufferGeometry();
-  geo.addAttribute("position", new BufferAttribute(varray, 3));
+  geo.setAttribute("position", new BufferAttribute(varray, 3, false));
   geo.setIndex(new BufferAttribute(inds, 1));
 
   geo.computeVertexNormals();

--- a/src/RayMarchedAtlasVolume.js
+++ b/src/RayMarchedAtlasVolume.js
@@ -74,7 +74,7 @@ export default class RayMarchedAtlasVolume {
     var mvm = new Matrix4();
     mvm.multiplyMatrices(canvas.camera.matrixWorldInverse, this.cubeMesh.matrixWorld);
     var mi = new Matrix4();
-    mi.getInverse(mvm);
+    mi.copy(mvm).invert();
 
     this.setUniform("inverseModelViewMatrix", mi, true, true);
 

--- a/src/VolumeDrawable.js
+++ b/src/VolumeDrawable.js
@@ -264,7 +264,8 @@ export default class VolumeDrawable {
     // TODO: this is inefficient, as this work is duplicated by threejs.
     // we need camera matrix up to date before giving the 3d objects a chance to use it.
     canvas.camera.updateMatrixWorld(true);
-    canvas.camera.matrixWorldInverse.getInverse(canvas.camera.matrixWorld);
+
+    canvas.camera.matrixWorldInverse.copy(canvas.camera.matrixWorld).invert();
 
     const isVR = canvas.isVR();
     if (isVR) {

--- a/src/vr/vrObjectControls.js
+++ b/src/vr/vrObjectControls.js
@@ -204,7 +204,7 @@ export class vrObjectControls {
       v1 = v1.normalize();
 
       var mio = new Matrix4();
-      mio.getInverse(obj3d.matrixWorld);
+      mio.copy(obj3d.matrixWorld).invert();
 
       v0 = v0.transformDirection(mio);
       v0 = v0.normalize();


### PR DESCRIPTION
Update threejs version to latest. 

Some small code fixups based on deprecation warnings:  matrix inverse has changed, and also they got rid of the Geometry class which caused one mesh data-filling function to be somewhat rewritten.

In testing the update, I found and fixed the following bug:

When updating a surface's isovalue, we destroy and re-create the surface, and to set the new surface to the correct color, the code was looking at the previous threejs object to find out what color it was.  But when the isovalue is changed to a value that doesn't generate any triangles, then there's no mesh in which to look up the color for the next change.

The fix is to just store the current colors (and opacities) in their own array.
