### PR TITLE
on color change in pathtrace mode, we need to update the combined LUT…

### DIFF
--- a/src/PathTracedVolume.js
+++ b/src/PathTracedVolume.js
@@ -670,7 +670,11 @@ export default class PathTracedVolume {
       let i = this.viewChannels[c];
       if (i > -1) {
         // diffuse color is actually blended into the LUT now.
+        const combinedLut = image.getChannel(c).combineLuts(image.getChannelColor(c));
+        this.pathTracingUniforms.g_lutTexture.value.image.data.set(combinedLut, i * LUT_ARRAY_LENGTH);
+        this.pathTracingUniforms.g_lutTexture.value.needsUpdate = true;
         this.pathTracingUniforms.g_diffuse.value[c] = new Vector3(1.0, 1.0, 1.0);
+
         this.pathTracingUniforms.g_specular.value[c] = new Vector3()
           .fromArray(image.specular[i])
           .multiplyScalar(1.0 / 255.0);

--- a/src/PathTracedVolume.js
+++ b/src/PathTracedVolume.js
@@ -670,8 +670,8 @@ export default class PathTracedVolume {
       let i = this.viewChannels[c];
       if (i > -1) {
         // diffuse color is actually blended into the LUT now.
-        const combinedLut = image.getChannel(c).combineLuts(image.getChannelColor(c));
-        this.pathTracingUniforms.g_lutTexture.value.image.data.set(combinedLut, i * LUT_ARRAY_LENGTH);
+        const combinedLut = image.getChannel(i).combineLuts(image.getChannelColor(i));
+        this.pathTracingUniforms.g_lutTexture.value.image.data.set(combinedLut, c * LUT_ARRAY_LENGTH);
         this.pathTracingUniforms.g_lutTexture.value.needsUpdate = true;
         this.pathTracingUniforms.g_diffuse.value[c] = new Vector3(1.0, 1.0, 1.0);
 


### PR DESCRIPTION
This is a bug that is a regression from adding the colorize mode.
In path trace mode, main channel color changes were not updating properly.  After this code change, colors update normally.

This happened because the main channel color is now part of the lookup table and is not stored as a separate individual color.  (A concession to colorize mode, since this color parameter needs to be per-intensity rather than global to the whole channel.)
A further optimization TODO would probably store some kind of "dirty" flag and only update things if something had changed.
