### PR TITLE
Bugfix/noise pattern

### DIFF
--- a/src/RayMarchedAtlasVolume.js
+++ b/src/RayMarchedAtlasVolume.js
@@ -102,6 +102,9 @@ export default class RayMarchedAtlasVolume {
     this.scale = scale;
 
     this.cubeMesh.scale.copy(new Vector3(scale.x, scale.y, scale.z));
+    this.setUniform("volumeScale", scale);
+    
+    console.log("scale= ", scale);
   }
 
   setRayStepSizes(primary, secondary) {}
@@ -161,6 +164,9 @@ export default class RayMarchedAtlasVolume {
       this.setOrthoThickness(thicknessPct);
     }
     // else don't set? use previous value?
+    else {
+      this.setOrthoThickness(1.0);
+    }
 
     this.setUniform("AABB_CLIP_MIN", this.bounds.bmin);
     this.setUniform("AABB_CLIP_MAX", this.bounds.bmax);

--- a/src/RayMarchedAtlasVolume.js
+++ b/src/RayMarchedAtlasVolume.js
@@ -162,8 +162,10 @@ export default class RayMarchedAtlasVolume {
       const thicknessPct = maxval - minval;
       this.setOrthoThickness(thicknessPct);
     }
-    // else don't set? use previous value?
     else {
+      // it is possible this is overly aggressive resetting this value here
+      // but testing has shown no ill effects and it is better to have a definite
+      // known value when in perspective mode
       this.setOrthoThickness(1.0);
     }
 

--- a/src/RayMarchedAtlasVolume.js
+++ b/src/RayMarchedAtlasVolume.js
@@ -104,8 +104,6 @@ export default class RayMarchedAtlasVolume {
 
     this.cubeMesh.scale.copy(new Vector3(scale.x, scale.y, scale.z));
     this.setUniform("volumeScale", scale);
-    
-    console.log("scale= ", scale);
   }
 
   setRayStepSizes(primary, secondary) {}

--- a/src/RayMarchedAtlasVolume.js
+++ b/src/RayMarchedAtlasVolume.js
@@ -42,6 +42,7 @@ export default class RayMarchedAtlasVolume {
 
     this.setUniform("ATLAS_X", volume.imageInfo.cols);
     this.setUniform("ATLAS_Y", volume.imageInfo.rows);
+    this.setUniform("textureRes", new Vector2(volume.imageInfo.atlas_width, volume.imageInfo.atlas_height));
     this.setUniform("SLICES", volume.z);
 
     this.channelData = new FusedChannelData(volume.imageInfo.atlas_width, volume.imageInfo.atlas_height);

--- a/src/constants/volumeRayMarchShader.js
+++ b/src/constants/volumeRayMarchShader.js
@@ -55,7 +55,7 @@ export const rayMarchingFragmentShaderSrc = [
   "  float threadId = gl_FragCoord.x/(gl_FragCoord.y + 1.0);",
   "  float bigVal = threadId*1299721.0/911.0;",
   "  vec2 smallVal = vec2(threadId*7927.0/577.0, threadId*104743.0/1039.0);",
-  "  return fract(sin(dot(co ,smallVal)) * bigVal);",
+  "  return fract(sin(dot(co, smallVal)) * bigVal);",
   "}",
 
   "vec4 luma2Alpha(vec4 color, float vmin, float vmax, float C){",
@@ -192,7 +192,7 @@ export const rayMarchingFragmentShaderSrc = [
   "  float invstep = 1.0/csteps;",
   // special-casing the single slice to remove the random ray dither.
   // this removes a Moire pattern visible in single slice images, which we want to view as 2D images as best we can.
-  "  float r = (SLICES==1.0) ?  0.0 : 0.5 - 1.0*rand(eye_d.xy);",
+  "  float r = (SLICES==1.0) ?  0.0 : 0.5 - 1.0*rand(gl_FragCoord.xy/iResolution.xy);",
   // if ortho and clipped, make step size smaller so we still get same number of steps
   "  float tstep = invstep*orthoThickness;",
   "  float tfarsurf = r*tstep;",

--- a/src/constants/volumeRayMarchShader.js
+++ b/src/constants/volumeRayMarchShader.js
@@ -20,22 +20,23 @@ export const rayMarchingFragmentShaderSrc = [
   "#define M_PI 3.14159265358979323846",
 
   "uniform vec2 iResolution;",
+  "uniform vec2 textureRes;",
   "uniform float GAMMA_MIN;",
   "uniform float GAMMA_MAX;",
   "uniform float GAMMA_SCALE;",
   "uniform float BRIGHTNESS;",
   "uniform float DENSITY;",
   "uniform float maskAlpha;",
-  "uniform sampler2D textureAtlas;",
-  "uniform sampler2D textureAtlasMask;",
-  "uniform int BREAK_STEPS;",
   "uniform float ATLAS_X;",
   "uniform float ATLAS_Y;",
-  "uniform float SLICES;",
   "uniform vec3 AABB_CLIP_MIN;",
   "uniform float CLIP_NEAR;",
   "uniform vec3 AABB_CLIP_MAX;",
   "uniform float CLIP_FAR;",
+  "uniform sampler2D textureAtlas;",
+  "uniform sampler2D textureAtlasMask;",
+  "uniform int BREAK_STEPS;",
+  "uniform float SLICES;",
   "uniform float isOrtho;",
   "uniform float orthoThickness;",
   "uniform float orthoScale;",
@@ -89,8 +90,9 @@ export const rayMarchingFragmentShaderSrc = [
   "  vec2 loc0 = vec2(",
   "    (flipVolume.x*(pos.x - 0.5) + 0.5)/ATLAS_X,",
   "    (flipVolume.y*(pos.y - 0.5) + 0.5)/ATLAS_Y);",
-  // shrink loc0 to within one edge texel?
-  //"loc0 += 0.5/2048.0;",
+  // loc ranges from 0 to 1/ATLAS_X, 1/ATLAS_Y
+  // shrink loc0 to within one half edge texel - so as not to sample across edges of tiles.
+  "loc0 = vec2(0.5/textureRes.x, 0.5/textureRes.y) + loc0*vec2(1.0-(ATLAS_X)/textureRes.x, 1.0-(ATLAS_Y)/textureRes.y);",
 
   // interpolate between two slices
 
@@ -105,8 +107,8 @@ export const rayMarchingFragmentShaderSrc = [
 
   // flipped:
   "if (flipVolume.z == -1.0) {",
-  "    z0 = nSlices - z0;",
-  "    z1 = nSlices - z1;",
+  "    z0 = nSlices - z0 - 1.0;",
+  "    z1 = nSlices - z1 - 1.0;",
   "    t = 1.0 - t;",
   "}",
 
@@ -391,6 +393,10 @@ export function rayMarchingShaderUniforms() {
     volumeScale: {
       type: "v3",
       value: new Vector3(1.0, 1.0, 1.0)
+    },
+    textureRes: {
+      type: "v2",
+      value: new Vector2(1.0, 1.0)
     }
   };
 }

--- a/src/constants/volumeRayMarchShader.js
+++ b/src/constants/volumeRayMarchShader.js
@@ -196,7 +196,6 @@ export const rayMarchingFragmentShaderSrc = [
   "  float scaledSteps = float(BREAK_STEPS) * length((eye_d.xyz/volumeScale));",
   "  float csteps = clamp(float(scaledSteps), 1.0, float(maxSteps));",
   "  float invstep = (tfar-tnear)/csteps;",
-//  "  float invstep = 1.0/csteps;",
   // special-casing the single slice to remove the random ray dither.
   // this removes a Moire pattern visible in single slice images, which we want to view as 2D images as best we can.
   "  float r = (SLICES==1.0) ?  0.0 : 0.5 - 1.0*rand(eye_d.xy);",

--- a/src/constants/volumeRayMarchShader.js
+++ b/src/constants/volumeRayMarchShader.js
@@ -41,6 +41,7 @@ export const rayMarchingFragmentShaderSrc = [
   "uniform float orthoScale;",
   "uniform int maxProject;",
   "uniform vec3 flipVolume;",
+  "uniform vec3 volumeScale;",
 
   // view space to axis-aligned volume box
   "uniform mat4 inverseModelViewMatrix;",
@@ -188,11 +189,13 @@ export const rayMarchingFragmentShaderSrc = [
 
   //'  //estimate step length',
   "  const int maxSteps = 512;",
+  "  float scaledSteps = float(BREAK_STEPS) * length((eye_d.xyz/volumeScale));",
   "  float csteps = clamp(float(BREAK_STEPS), 1.0, float(maxSteps));",
-  "  float invstep = 1.0/csteps;",
+  "  float invstep = (tfar-tnear)/csteps;",
+//  "  float invstep = 1.0/csteps;",
   // special-casing the single slice to remove the random ray dither.
   // this removes a Moire pattern visible in single slice images, which we want to view as 2D images as best we can.
-  "  float r = (SLICES==1.0) ?  0.0 : 0.5 - 1.0*rand(gl_FragCoord.xy/iResolution.xy);",
+  "  float r = (SLICES==1.0) ?  0.0 : 0.5 - 1.0*rand(eye_d.xy);",
   // if ortho and clipped, make step size smaller so we still get same number of steps
   "  float tstep = invstep*orthoThickness;",
   "  float tfarsurf = r*tstep;",
@@ -381,5 +384,9 @@ export function rayMarchingShaderUniforms() {
       type: "v3",
       value: new Vector3(1.0, 1.0, 1.0),
     },
+    volumeScale: {
+      type: "v3",
+      value: new Vector3(1.0, 1.0, 1.0)
+    }
   };
 }

--- a/src/constants/volumeRayMarchShader.js
+++ b/src/constants/volumeRayMarchShader.js
@@ -96,8 +96,6 @@ export const rayMarchingFragmentShaderSrc = [
 
   // interpolate between two slices
 
-  // this 0.0001 fudge factor fixes a bug when the volume is clipped to a single slice boundary.
-  // Basically I am pushing the number just slightly off of an integer multiple.
   "  float z = (pos.z)*(nSlices-1.0);",
   "  float zfloor = floor(z);",
   "  float z0  = zfloor;",


### PR DESCRIPTION
Two bug fixes are included here.
1. In some volumes, (I believe this might be limited to texture atlases whose tiles fill the entire texture space with no empty tiles at the end), there was a banding artifact at the top or bottom edge of the volume.
![image (1)](https://user-images.githubusercontent.com/2193409/131556282-7a78d7ca-9fa6-4586-9975-17b8e76c7ff9.png)
2. There was excessive noise when looking at side views of the volume.
![image (2)](https://user-images.githubusercontent.com/2193409/131556538-e70108ce-57bb-406b-b5b0-81f323aec100.png)

Bug 1 was fixed by correcting the way I select the z slices from which to sample.  This was cleaned up and there seemed to be a clear off-by-one error in there.

Bug 2 was "improved" but not 100% resolved, by changing the step sizes for ray marching through the volume.  The step size now accounts for the nonuniform scale of the volume cube, which was implicitly folded into the transformation of the ray direction.  Noise is inherent to this volume rendering algorithm, and is intentional to overcome aliasing.