### PR TITLE
Fix/handle same min-max values in lutGenerator_minMax

### DIFF
--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -16,16 +16,16 @@ const LUT_ENTRIES = 256;
 const LUT_ARRAY_LENGTH = LUT_ENTRIES * 4;
 
 /**
- * @typedef {Object} ControlPoint
+ * @typedef {Object} ControlPoint Used for the TF (transfer function) editor GUI. Need to be converted to LUT for rendering.
  * @property {number} x The X Coordinate
  * @property {number} opacity The Opacity, from 0 to 1
  * @property {Array.<number>} color The Color, 3 numbers from 0-255 for r,g,b
  */
 
 /**
- * @typedef {Object} Lut
- * @property {Array.<number>} lut LUT_ARRAY_LENGTH element lookup table as array (maps scalar intensity to a rgb color plus alpha)
- * @property {Array.<ControlPoint>} controlPoints
+ * @typedef {Object} Lut Used for rendering.
+ * @property {Array.<number>} lut LUT_ARRAY_LENGTH element lookup table as array (maps scalar intensity to a rgb color plus alpha, with each value from 0-255))
+ * @property {Array.<ControlPoint>} controlPoints 
  */
 type ControlPoint = {
   x: number;

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -172,11 +172,7 @@ export default class Histogram {
     // Add starting point at x = 0
     let startVal = 0;
     if (b < 0) {
-      if (e === b) {
-        startVal = 1;
-      } else {
-        startVal = -b / (e - b);
-      }
+      startVal = -b / (e - b);
     }
     controlPoints.push({ x: 0, opacity: startVal, color: [255, 255, 255] });
     

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -156,7 +156,7 @@ export default class Histogram {
         ],
       };
     }
-    if (b > 255 && e > 255) {
+    if (b >= 255 && e >= 255) {
       return {
         lut: lut,
         controlPoints: [
@@ -193,12 +193,8 @@ export default class Histogram {
 
     // Add ending point at x = 255
     let endVal = 1;
-    if (e >= 255) {
-      if (e === b) {
-        endVal = 0;
-      } else {
-        endVal = (255 - b) / (e - b);
-      }
+    if (e > 255) {
+      endVal = (255 - b) / (e - b);
     }
     controlPoints.push({ x: 255, opacity: endVal, color: [255, 255, 255] });
 

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -103,7 +103,7 @@ export default class Histogram {
   }
 
   /**
-   * Generate a piecewise linear lookup table that ramps up from 0 to 1 over the b to e domain
+   * Generate a piecewise linear lookup table that ramps up from 0 to 1 over the b to e domain. If e === b, then we use a step function with f(b) = 0 and f(b + 1) = 1
    *  |
    * 1|               +---------+-----
    *  |              /
@@ -135,7 +135,6 @@ export default class Histogram {
         lut[x * 4 + 3] = 0;
       } else {
         if (e === b) {
-          // singularity. can this be reached?
           lut[x * 4 + 3] = 255;
         } else {
           const a = (x - b) / (e - b);
@@ -146,19 +145,32 @@ export default class Histogram {
 
     const controlPoints: ControlPoint[] = [];
     let startVal = 0;
-    if (b <= 0) {
-      startVal = -b / (e - b);
+    if (b < 0) {
+      if (e === b) {
+        startVal = 1;
+      } else {
+        startVal = -b / (e - b);
+      }
     }
     controlPoints.push({ x: 0, opacity: startVal, color: [255, 255, 255] });
     if (b > 0) {
       controlPoints.push({ x: b, opacity: 0, color: [255, 255, 255] });
     }
+    
     if (e < 255) {
-      controlPoints.push({ x: e, opacity: 1, color: [255, 255, 255] });
+      if (e === b) {
+        controlPoints.push({ x: b + 0.5, opacity: 1, color: [255, 255, 255] });
+      } else {
+        controlPoints.push({ x: e, opacity: 1, color: [255, 255, 255] });
+      }
     }
     let endVal = 1;
     if (e >= 255) {
-      endVal = (255 - b) / (e - b);
+      if (e === b) {
+        endVal = 0;
+      } else {
+        endVal = (255 - b) / (e - b);
+      }
     }
     controlPoints.push({ x: 255, opacity: endVal, color: [255, 255, 255] });
 

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -147,7 +147,6 @@ export default class Histogram {
     }
 
     // Edge case: b and e are both out of bounds 
-    // (both are negative or both are greater than 255)
     if (b < 0 && e < 0) {
       return {
         lut: lut,

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -16,7 +16,8 @@ const LUT_ENTRIES = 256;
 const LUT_ARRAY_LENGTH = LUT_ENTRIES * 4;
 
 /**
- * @typedef {Object} ControlPoint Used for the TF (transfer function) editor GUI. Need to be converted to LUT for rendering.
+ * @typedef {Object} ControlPoint Used for the TF (transfer function) editor GUI. 
+ * Need to be converted to LUT for rendering.
  * @property {number} x The X Coordinate
  * @property {number} opacity The Opacity, from 0 to 1
  * @property {Array.<number>} color The Color, 3 numbers from 0-255 for r,g,b
@@ -24,7 +25,8 @@ const LUT_ARRAY_LENGTH = LUT_ENTRIES * 4;
 
 /**
  * @typedef {Object} Lut Used for rendering.
- * @property {Array.<number>} lut LUT_ARRAY_LENGTH element lookup table as array (maps scalar intensity to a rgb color plus alpha, with each value from 0-255))
+ * @property {Array.<number>} lut LUT_ARRAY_LENGTH element lookup table as array 
+ * (maps scalar intensity to a rgb color plus alpha, with each value from 0-255)
  * @property {Array.<ControlPoint>} controlPoints 
  */
 type ControlPoint = {
@@ -103,7 +105,8 @@ export default class Histogram {
   }
 
   /**
-   * Generate a piecewise linear lookup table that ramps up from 0 to 1 over the b to e domain. If e === b, then we use a step function with f(b) = 0 and f(b + 1) = 1
+   * Generate a piecewise linear lookup table that ramps up from 0 to 1 over the b to e domain. 
+   * If e === b, then we use a step function with f(b) = 0 and f(b + 1) = 1
    *  |
    * 1|               +---------+-----
    *  |              /
@@ -112,7 +115,7 @@ export default class Histogram {
    *  |           /
    *  |          /
    * 0+=========+---------------+-----
-   *  0         b    e          1
+   *  0         b    e         255
    * @return {Lut}
    * @param {number} b
    * @param {number} e
@@ -143,7 +146,10 @@ export default class Histogram {
       }
     }
 
+    // Generate 2 to 4 control points for a minMax LUT, from left to right
     const controlPoints: ControlPoint[] = [];
+
+    // Add starting point at x = 0
     let startVal = 0;
     if (b < 0) {
       if (e === b) {
@@ -153,17 +159,23 @@ export default class Histogram {
       }
     }
     controlPoints.push({ x: 0, opacity: startVal, color: [255, 255, 255] });
+    
+    // If b > 0, add another point at (b, 0)
     if (b > 0) {
       controlPoints.push({ x: b, opacity: 0, color: [255, 255, 255] });
     }
     
+    // If e < 255, Add another point at (e, 1)
     if (e < 255) {
       if (e === b) {
+        // Use b + 0.5 as x value instead of e to create a near-vertical ramp 
         controlPoints.push({ x: b + 0.5, opacity: 1, color: [255, 255, 255] });
       } else {
         controlPoints.push({ x: e, opacity: 1, color: [255, 255, 255] });
       }
     }
+
+    // Add ending point at x = 255
     let endVal = 1;
     if (e >= 255) {
       if (e === b) {

--- a/src/Histogram.ts
+++ b/src/Histogram.ts
@@ -146,6 +146,27 @@ export default class Histogram {
       }
     }
 
+    // Edge case: b and e are both out of bounds 
+    // (both are negative or both are greater than 255)
+    if (b < 0 && e < 0) {
+      return {
+        lut: lut,
+        controlPoints: [
+          { x: 0, opacity: 1, color: [255, 255, 255] },
+          { x: 255, opacity: 1, color: [255, 255, 255] }
+        ],
+      };
+    }
+    if (b > 255 && e > 255) {
+      return {
+        lut: lut,
+        controlPoints: [
+          { x: 0, opacity: 0, color: [255, 255, 255] },
+          { x: 255, opacity: 0, color: [255, 255, 255] }
+        ],
+      };
+    }
+
     // Generate 2 to 4 control points for a minMax LUT, from left to right
     const controlPoints: ControlPoint[] = [];
 

--- a/src/test/lut.test.js
+++ b/src/test/lut.test.js
@@ -123,7 +123,7 @@ describe("test histogram", () => {
       data[i] = clamp(Math.floor(Math.random() * 256), 0, 255);
     }
     const histogram = new Histogram(data);
-    describe("luGenerator_minMax", () => {
+    describe("lutGenerator_minMax", () => {
       it("is consistent for minMax (typical case)", () => {
         const lut = histogram.lutGenerator_minMax(64, 192);
         const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
@@ -264,7 +264,7 @@ describe("test histogram", () => {
       //   expect(lut.lut).to.eql(secondlut.lut);
       // });
     });
-    
+
     it("is consistent for fullRange", () => {
       const lut = histogram.lutGenerator_fullRange();
       const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);

--- a/src/test/lut.test.js
+++ b/src/test/lut.test.js
@@ -166,6 +166,22 @@ describe("test histogram", () => {
         expect(controlPoint.opacity).to.be.finite;
       })
     });
+    it("is consistent for minMax edge case -10,-5", () => {
+      const lut = histogram.lutGenerator_minMax(-10, -5);
+      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+      expect(lut.lut).to.eql(secondlut.lut);
+      // Spot check but all opacity values should be 255
+      expect(lut.lut[3]).to.eql(255);
+      expect(secondlut.lut[3]).to.eql(255);
+      expect(lut.lut[120 * 4 + 3]).to.eql(255);
+      expect(secondlut.lut[120 * 4 + 3]).to.eql(255);
+      expect(lut.lut[255 * 4 + 3]).to.eql(255);
+      expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
+      // Make sure no NaN values
+      lut.controlPoints.forEach(controlPoint => {
+        expect(controlPoint.opacity).to.be.finite;
+      })
+    });
     it("is consistent for minMax edge case 0,1", () => {
       const lut = histogram.lutGenerator_minMax(0, 1);
       const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
@@ -202,6 +218,22 @@ describe("test histogram", () => {
       expect(lut.lut).to.eql(secondlut.lut);
       expect(lut.lut[3]).to.eql(0);
       expect(secondlut.lut[3]).to.eql(0);
+      expect(lut.lut[255 * 4 + 3]).to.eql(0);
+      expect(secondlut.lut[255 * 4 + 3]).to.eql(0);
+      // Make sure no NaN values
+      lut.controlPoints.forEach(controlPoint => {
+        expect(controlPoint.opacity).to.be.finite;
+      })
+    });
+    it("is consistent for minMax edge case 300,400", () => {
+      const lut = histogram.lutGenerator_minMax(300, 400);
+      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+      expect(lut.lut).to.eql(secondlut.lut);
+      // Spot check but all opacity values should be 0
+      expect(lut.lut[3]).to.eql(0);
+      expect(secondlut.lut[3]).to.eql(0);
+      expect(lut.lut[120 * 4 + 3]).to.eql(0);
+      expect(secondlut.lut[120 * 4 + 3]).to.eql(0);
       expect(lut.lut[255 * 4 + 3]).to.eql(0);
       expect(secondlut.lut[255 * 4 + 3]).to.eql(0);
       // Make sure no NaN values

--- a/src/test/lut.test.js
+++ b/src/test/lut.test.js
@@ -144,6 +144,27 @@ describe("test histogram", () => {
       expect(secondlut.lut[1 * 4 + 3]).to.eql(255);
       expect(lut.lut[255 * 4 + 3]).to.eql(255);
       expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
+      // Make sure no NaN values
+      lut.controlPoints.forEach(controlPoint => {
+        expect(controlPoint.opacity).to.be.finite;
+      })
+    });
+    it("is consistent for minMax edge case 120,120", () => {
+      const lut = histogram.lutGenerator_minMax(120, 120);
+      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+      expect(lut.lut).to.eql(secondlut.lut);
+      expect(lut.lut[3]).to.eql(0);
+      expect(secondlut.lut[3]).to.eql(0);
+      expect(lut.lut[120 * 4 + 3]).to.eql(0);
+      expect(secondlut.lut[120 * 4 + 3]).to.eql(0);
+      expect(lut.lut[121 * 4 + 3]).to.eql(255);
+      expect(secondlut.lut[121 * 4 + 3]).to.eql(255);
+      expect(lut.lut[255 * 4 + 3]).to.eql(255);
+      expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
+      // Make sure no NaN values
+      lut.controlPoints.forEach(controlPoint => {
+        expect(controlPoint.opacity).to.be.finite;
+      })
     });
     it("is consistent for minMax edge case 0,1", () => {
       const lut = histogram.lutGenerator_minMax(0, 1);
@@ -155,6 +176,10 @@ describe("test histogram", () => {
       expect(secondlut.lut[1 * 4 + 3]).to.eql(255);
       expect(lut.lut[255 * 4 + 3]).to.eql(255);
       expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
+      // Make sure no NaN values
+      lut.controlPoints.forEach(controlPoint => {
+        expect(controlPoint.opacity).to.be.finite;
+      })
     });
     it("is consistent for minMax edge case 254,255", () => {
       const lut = histogram.lutGenerator_minMax(254, 255);
@@ -166,6 +191,10 @@ describe("test histogram", () => {
       expect(secondlut.lut[254 * 4 + 3]).to.eql(0);
       expect(lut.lut[255 * 4 + 3]).to.eql(255);
       expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
+      // Make sure no NaN values
+      lut.controlPoints.forEach(controlPoint => {
+        expect(controlPoint.opacity).to.be.finite;
+      })
     });
     it("is consistent for minMax edge case 255,255", () => {
       const lut = histogram.lutGenerator_minMax(255, 255);
@@ -175,6 +204,10 @@ describe("test histogram", () => {
       expect(secondlut.lut[3]).to.eql(0);
       expect(lut.lut[255 * 4 + 3]).to.eql(0);
       expect(secondlut.lut[255 * 4 + 3]).to.eql(0);
+      // Make sure no NaN values
+      lut.controlPoints.forEach(controlPoint => {
+        expect(controlPoint.opacity).to.be.finite;
+      })
     });
 
     it("is consistent for windowLevel", () => {

--- a/src/test/lut.test.js
+++ b/src/test/lut.test.js
@@ -177,9 +177,8 @@ describe("test histogram", () => {
       expect(secondlut.lut[120 * 4 + 3]).to.eql(255);
       expect(lut.lut[255 * 4 + 3]).to.eql(255);
       expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
-      // Make sure no NaN values
       lut.controlPoints.forEach(controlPoint => {
-        expect(controlPoint.opacity).to.be.finite;
+        expect(controlPoint.opacity).to.eql(1);
       })
     });
     it("is consistent for minMax edge case 0,1", () => {
@@ -220,9 +219,8 @@ describe("test histogram", () => {
       expect(secondlut.lut[3]).to.eql(0);
       expect(lut.lut[255 * 4 + 3]).to.eql(0);
       expect(secondlut.lut[255 * 4 + 3]).to.eql(0);
-      // Make sure no NaN values
       lut.controlPoints.forEach(controlPoint => {
-        expect(controlPoint.opacity).to.be.finite;
+        expect(controlPoint.opacity).to.eql(0);
       })
     });
     it("is consistent for minMax edge case 300,400", () => {
@@ -236,9 +234,8 @@ describe("test histogram", () => {
       expect(secondlut.lut[120 * 4 + 3]).to.eql(0);
       expect(lut.lut[255 * 4 + 3]).to.eql(0);
       expect(secondlut.lut[255 * 4 + 3]).to.eql(0);
-      // Make sure no NaN values
       lut.controlPoints.forEach(controlPoint => {
-        expect(controlPoint.opacity).to.be.finite;
+        expect(controlPoint.opacity).to.eql(0);
       })
     });
 

--- a/src/test/lut.test.js
+++ b/src/test/lut.test.js
@@ -123,144 +123,148 @@ describe("test histogram", () => {
       data[i] = clamp(Math.floor(Math.random() * 256), 0, 255);
     }
     const histogram = new Histogram(data);
+    describe("luGenerator_minMax", () => {
+      it("is consistent for minMax (typical case)", () => {
+        const lut = histogram.lutGenerator_minMax(64, 192);
+        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        expect(lut.lut).to.eql(secondlut.lut);
+      });
+      it("is consistent for minMax full range", () => {
+        const lut = histogram.lutGenerator_minMax(0, 255);
+        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        expect(lut.lut).to.eql(secondlut.lut);
+      });
+      it("is consistent when min and max are both 0", () => {
+        const lut = histogram.lutGenerator_minMax(0, 0);
+        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        expect(lut.lut).to.eql(secondlut.lut);
+        expect(lut.lut[3]).to.eql(0);
+        expect(secondlut.lut[3]).to.eql(0);
+        expect(lut.lut[1 * 4 + 3]).to.eql(255);
+        expect(secondlut.lut[1 * 4 + 3]).to.eql(255);
+        expect(lut.lut[255 * 4 + 3]).to.eql(255);
+        expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
+        // Make sure no NaN values
+        lut.controlPoints.forEach(controlPoint => {
+          expect(controlPoint.opacity).to.be.finite;
+        })
+      });
+      it("is consistent when min and max are the same positive number less than 255", () => {
+        const lut = histogram.lutGenerator_minMax(120, 120);
+        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        expect(lut.lut).to.eql(secondlut.lut);
+        expect(lut.lut[3]).to.eql(0);
+        expect(secondlut.lut[3]).to.eql(0);
+        expect(lut.lut[120 * 4 + 3]).to.eql(0);
+        expect(secondlut.lut[120 * 4 + 3]).to.eql(0);
+        expect(lut.lut[121 * 4 + 3]).to.eql(255);
+        expect(secondlut.lut[121 * 4 + 3]).to.eql(255);
+        expect(lut.lut[255 * 4 + 3]).to.eql(255);
+        expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
+        // Make sure no NaN values
+        lut.controlPoints.forEach(controlPoint => {
+          expect(controlPoint.opacity).to.be.finite;
+        })
+      });
+      it("is consistent when min and max are both negative", () => {
+        const lut = histogram.lutGenerator_minMax(-10, -5);
+        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        expect(lut.lut).to.eql(secondlut.lut);
+        // Spot check but all opacity values should be 255
+        expect(lut.lut[3]).to.eql(255);
+        expect(secondlut.lut[3]).to.eql(255);
+        expect(lut.lut[120 * 4 + 3]).to.eql(255);
+        expect(secondlut.lut[120 * 4 + 3]).to.eql(255);
+        expect(lut.lut[255 * 4 + 3]).to.eql(255);
+        expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
+        lut.controlPoints.forEach(controlPoint => {
+          expect(controlPoint.opacity).to.eql(1);
+        })
+      });
+      it("is consistent when min is 0 and max is 1", () => {
+        const lut = histogram.lutGenerator_minMax(0, 1);
+        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        expect(lut.lut).to.eql(secondlut.lut);
+        expect(lut.lut[3]).to.eql(0);
+        expect(secondlut.lut[3]).to.eql(0);
+        expect(lut.lut[1 * 4 + 3]).to.eql(255);
+        expect(secondlut.lut[1 * 4 + 3]).to.eql(255);
+        expect(lut.lut[255 * 4 + 3]).to.eql(255);
+        expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
+        // Make sure no NaN values
+        lut.controlPoints.forEach(controlPoint => {
+          expect(controlPoint.opacity).to.be.finite;
+        })
+      });
+      it("is consistent when min is 244 and max is 255", () => {
+        const lut = histogram.lutGenerator_minMax(254, 255);
+        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        expect(lut.lut).to.eql(secondlut.lut);
+        expect(lut.lut[3]).to.eql(0);
+        expect(secondlut.lut[3]).to.eql(0);
+        expect(lut.lut[254 * 4 + 3]).to.eql(0);
+        expect(secondlut.lut[254 * 4 + 3]).to.eql(0);
+        expect(lut.lut[255 * 4 + 3]).to.eql(255);
+        expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
+        // Make sure no NaN values
+        lut.controlPoints.forEach(controlPoint => {
+          expect(controlPoint.opacity).to.be.finite;
+        })
+      });
+      it("is consistent when min and max are both 255", () => {
+        const lut = histogram.lutGenerator_minMax(255, 255);
+        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        expect(lut.lut).to.eql(secondlut.lut);
+        expect(lut.lut[3]).to.eql(0);
+        expect(secondlut.lut[3]).to.eql(0);
+        expect(lut.lut[255 * 4 + 3]).to.eql(0);
+        expect(secondlut.lut[255 * 4 + 3]).to.eql(0);
+        lut.controlPoints.forEach(controlPoint => {
+          expect(controlPoint.opacity).to.eql(0);
+        })
+      });
+      it("is consistent when min and max are both greater than 255", () => {
+        const lut = histogram.lutGenerator_minMax(300, 400);
+        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        expect(lut.lut).to.eql(secondlut.lut);
+        // Spot check but all opacity values should be 0
+        expect(lut.lut[3]).to.eql(0);
+        expect(secondlut.lut[3]).to.eql(0);
+        expect(lut.lut[120 * 4 + 3]).to.eql(0);
+        expect(secondlut.lut[120 * 4 + 3]).to.eql(0);
+        expect(lut.lut[255 * 4 + 3]).to.eql(0);
+        expect(secondlut.lut[255 * 4 + 3]).to.eql(0);
+        lut.controlPoints.forEach(controlPoint => {
+          expect(controlPoint.opacity).to.eql(0);
+        })
+      });
+    });
 
-    it("is consistent for minMax", () => {
-      const lut = histogram.lutGenerator_minMax(64, 192);
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
-      expect(lut.lut).to.eql(secondlut.lut);
+    describe("lutGenerator_windowLevel", () => {
+      it("is consistent for windowLevel", () => {
+        const lut = histogram.lutGenerator_windowLevel(0.25, 0.333);
+        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        expect(lut.lut).to.eql(secondlut.lut);
+      });
+      it("is consistent for windowLevel extending below bounds", () => {
+        const lut = histogram.lutGenerator_windowLevel(0.5, 0.25);
+        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        expect(lut.lut).to.eql(secondlut.lut);
+      });
+      it("is consistent for windowLevel extending above bounds", () => {
+        const lut = histogram.lutGenerator_windowLevel(0.5, 0.75);
+        const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+        expect(lut.lut).to.eql(secondlut.lut);
+      });
+      // TODO this test almost works but there are some very slight rounding errors
+      // keeping things from being perfectly equal. Need to work out the precision issue.
+      // it("is consistent for windowLevel extending beyond bounds", () => {
+      //   const lut = histogram.lutGenerator_windowLevel(1.5, 0.5);
+      //   const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
+      //   expect(lut.lut).to.eql(secondlut.lut);
+      // });
     });
-    it("is consistent for minMax full range", () => {
-      const lut = histogram.lutGenerator_minMax(0, 255);
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
-      expect(lut.lut).to.eql(secondlut.lut);
-    });
-    it("is consistent for minMax edge case 0,0", () => {
-      const lut = histogram.lutGenerator_minMax(0, 0);
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
-      expect(lut.lut).to.eql(secondlut.lut);
-      expect(lut.lut[3]).to.eql(0);
-      expect(secondlut.lut[3]).to.eql(0);
-      expect(lut.lut[1 * 4 + 3]).to.eql(255);
-      expect(secondlut.lut[1 * 4 + 3]).to.eql(255);
-      expect(lut.lut[255 * 4 + 3]).to.eql(255);
-      expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
-      // Make sure no NaN values
-      lut.controlPoints.forEach(controlPoint => {
-        expect(controlPoint.opacity).to.be.finite;
-      })
-    });
-    it("is consistent for minMax edge case 120,120", () => {
-      const lut = histogram.lutGenerator_minMax(120, 120);
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
-      expect(lut.lut).to.eql(secondlut.lut);
-      expect(lut.lut[3]).to.eql(0);
-      expect(secondlut.lut[3]).to.eql(0);
-      expect(lut.lut[120 * 4 + 3]).to.eql(0);
-      expect(secondlut.lut[120 * 4 + 3]).to.eql(0);
-      expect(lut.lut[121 * 4 + 3]).to.eql(255);
-      expect(secondlut.lut[121 * 4 + 3]).to.eql(255);
-      expect(lut.lut[255 * 4 + 3]).to.eql(255);
-      expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
-      // Make sure no NaN values
-      lut.controlPoints.forEach(controlPoint => {
-        expect(controlPoint.opacity).to.be.finite;
-      })
-    });
-    it("is consistent for minMax edge case -10,-5", () => {
-      const lut = histogram.lutGenerator_minMax(-10, -5);
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
-      expect(lut.lut).to.eql(secondlut.lut);
-      // Spot check but all opacity values should be 255
-      expect(lut.lut[3]).to.eql(255);
-      expect(secondlut.lut[3]).to.eql(255);
-      expect(lut.lut[120 * 4 + 3]).to.eql(255);
-      expect(secondlut.lut[120 * 4 + 3]).to.eql(255);
-      expect(lut.lut[255 * 4 + 3]).to.eql(255);
-      expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
-      lut.controlPoints.forEach(controlPoint => {
-        expect(controlPoint.opacity).to.eql(1);
-      })
-    });
-    it("is consistent for minMax edge case 0,1", () => {
-      const lut = histogram.lutGenerator_minMax(0, 1);
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
-      expect(lut.lut).to.eql(secondlut.lut);
-      expect(lut.lut[3]).to.eql(0);
-      expect(secondlut.lut[3]).to.eql(0);
-      expect(lut.lut[1 * 4 + 3]).to.eql(255);
-      expect(secondlut.lut[1 * 4 + 3]).to.eql(255);
-      expect(lut.lut[255 * 4 + 3]).to.eql(255);
-      expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
-      // Make sure no NaN values
-      lut.controlPoints.forEach(controlPoint => {
-        expect(controlPoint.opacity).to.be.finite;
-      })
-    });
-    it("is consistent for minMax edge case 254,255", () => {
-      const lut = histogram.lutGenerator_minMax(254, 255);
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
-      expect(lut.lut).to.eql(secondlut.lut);
-      expect(lut.lut[3]).to.eql(0);
-      expect(secondlut.lut[3]).to.eql(0);
-      expect(lut.lut[254 * 4 + 3]).to.eql(0);
-      expect(secondlut.lut[254 * 4 + 3]).to.eql(0);
-      expect(lut.lut[255 * 4 + 3]).to.eql(255);
-      expect(secondlut.lut[255 * 4 + 3]).to.eql(255);
-      // Make sure no NaN values
-      lut.controlPoints.forEach(controlPoint => {
-        expect(controlPoint.opacity).to.be.finite;
-      })
-    });
-    it("is consistent for minMax edge case 255,255", () => {
-      const lut = histogram.lutGenerator_minMax(255, 255);
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
-      expect(lut.lut).to.eql(secondlut.lut);
-      expect(lut.lut[3]).to.eql(0);
-      expect(secondlut.lut[3]).to.eql(0);
-      expect(lut.lut[255 * 4 + 3]).to.eql(0);
-      expect(secondlut.lut[255 * 4 + 3]).to.eql(0);
-      lut.controlPoints.forEach(controlPoint => {
-        expect(controlPoint.opacity).to.eql(0);
-      })
-    });
-    it("is consistent for minMax edge case 300,400", () => {
-      const lut = histogram.lutGenerator_minMax(300, 400);
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
-      expect(lut.lut).to.eql(secondlut.lut);
-      // Spot check but all opacity values should be 0
-      expect(lut.lut[3]).to.eql(0);
-      expect(secondlut.lut[3]).to.eql(0);
-      expect(lut.lut[120 * 4 + 3]).to.eql(0);
-      expect(secondlut.lut[120 * 4 + 3]).to.eql(0);
-      expect(lut.lut[255 * 4 + 3]).to.eql(0);
-      expect(secondlut.lut[255 * 4 + 3]).to.eql(0);
-      lut.controlPoints.forEach(controlPoint => {
-        expect(controlPoint.opacity).to.eql(0);
-      })
-    });
-
-    it("is consistent for windowLevel", () => {
-      const lut = histogram.lutGenerator_windowLevel(0.25, 0.333);
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
-      expect(lut.lut).to.eql(secondlut.lut);
-    });
-    it("is consistent for windowLevel extending below bounds", () => {
-      const lut = histogram.lutGenerator_windowLevel(0.5, 0.25);
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
-      expect(lut.lut).to.eql(secondlut.lut);
-    });
-    it("is consistent for windowLevel extending above bounds", () => {
-      const lut = histogram.lutGenerator_windowLevel(0.5, 0.75);
-      const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
-      expect(lut.lut).to.eql(secondlut.lut);
-    });
-    // TODO this test almost works but there are some very slight rounding errors
-    // keeping things from being perfectly equal. Need to work out the precision issue.
-    // it("is consistent for windowLevel extending beyond bounds", () => {
-    //   const lut = histogram.lutGenerator_windowLevel(1.5, 0.5);
-    //   const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);
-    //   expect(lut.lut).to.eql(secondlut.lut);
-    // });
+    
     it("is consistent for fullRange", () => {
       const lut = histogram.lutGenerator_fullRange();
       const secondlut = histogram.lutGenerator_fromControlPoints(lut.controlPoints);


### PR DESCRIPTION
This should fix the bug we're currently seeing in CFE / website-3d-cell-viewer: [website-3d-cell-viewer crashes when trying to view volume settings for contour channels](https://aicsjira.corp.alleninstitute.org/browse/ANIMCELLGR-686)

### Cause of bug: 
NaN values getting passed in as control points. The NaN values were coming from divisions by zero that were happening in the case where the min and max values passed into the min-max lookup table generator (`lutGenerator_minMax` in Histogram.ts) were equal. The direct lookup table generation was handling the case where min = max (`b === e`) but the code that generates control points was not handling that case.

### Solution: 
Add more assertions to tests to check that no NaN values are generated, and modify control point generation logic to deal with min and max values being equal (avoid division by zero and create a step function with an almost vertical slope)

### Other changes:
- Wrote tests for a few more edge cases and wrote more code to make those tests pass
- Added comments (hopefully they're accurate)

@toloudis and I worked on this together.


**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes.
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
