### PR TITLE
Feature/draw bounding box

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,7 @@
     </p>
     <p style="margin:2px;">
         <button id="showBoundingBox">Bounds</button>
+        <input type="color" id="boundingBoxColor" value="#ffff00">
         <button id="flipXBtn">FlipX</button>
         <button id="flipYBtn">FlipY</button>
         <button id="flipZBtn">FlipZ</button>

--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,7 @@
         <button id="screenshotBtn">Screenshot</button>
     </p>
     <p style="margin:2px;">
+        <button id="showBoundingBox">Bounds</button>
         <button id="flipXBtn">FlipX</button>
         <button id="flipYBtn">FlipY</button>
         <button id="flipZBtn">FlipZ</button>

--- a/public/index.ts
+++ b/public/index.ts
@@ -64,6 +64,7 @@ const myState: State = {
   isAxisShowing: false,
   isAligned: true,
 
+  showBoundingBox: false,
   flipX: 1,
   flipY: 1,
   flipZ: 1,
@@ -138,7 +139,7 @@ function initLights() {
   view3D.updateLights(myState.lights);
 }
 
-let gui:dat.GUI;
+let gui: dat.GUI;
 
 function setupGui() {
   gui = new dat.GUI();
@@ -465,7 +466,7 @@ function removeFolderByName(name: string) {
   delete gui.__folders[name];
   // @ts-expect-error onResize doesn't exist in the type declaration
   gui.onResize();
-};
+}
 
 function showChannelUI(volume: Volume) {
   if (myState && myState.channelFolderNames) {
@@ -1015,6 +1016,11 @@ function main() {
   axisBtn?.addEventListener("click", () => {
     myState.isAxisShowing = !myState.isAxisShowing;
     view3D.setShowAxis(myState.isAxisShowing);
+  });
+  const showBoundsBtn = document.getElementById("showBoundingBox");
+  showBoundsBtn?.addEventListener("click", () => {
+    myState.showBoundingBox = !myState.showBoundingBox;
+    view3D.setShowBoundingBox(myState.volume, myState.showBoundingBox);
   });
   const flipXBtn = document.getElementById("flipXBtn");
   flipXBtn?.addEventListener("click", () => {

--- a/public/index.ts
+++ b/public/index.ts
@@ -151,7 +151,7 @@ function setupGui() {
     .max(100.0)
     .min(0.0)
     .step(0.001)
-    .onChange(function (value) {
+    .onChange(function(value) {
       view3D.updateDensity(myState.volume, value / 50.0);
     });
   gui
@@ -159,7 +159,7 @@ function setupGui() {
     .max(1.0)
     .min(0.0)
     .step(0.001)
-    .onChange(function (value) {
+    .onChange(function(value) {
       view3D.updateMaskAlpha(myState.volume, value);
     });
   gui
@@ -167,7 +167,7 @@ function setupGui() {
     .max(40.0)
     .min(1.0)
     .step(0.1)
-    .onChange(function () {
+    .onChange(function() {
       view3D.setRayStepSizes(myState.volume, myState.primaryRay, myState.secondaryRay);
     });
   gui
@@ -175,7 +175,7 @@ function setupGui() {
     .max(40.0)
     .min(1.0)
     .step(0.1)
-    .onChange(function () {
+    .onChange(function() {
       view3D.setRayStepSizes(myState.volume, myState.primaryRay, myState.secondaryRay);
     });
 
@@ -185,7 +185,7 @@ function setupGui() {
     .max(1.0)
     .min(0.0)
     .step(0.001)
-    .onChange(function (value) {
+    .onChange(function(value) {
       view3D.updateExposure(value);
     });
   cameraGui
@@ -193,7 +193,7 @@ function setupGui() {
     .max(0.1)
     .min(0.0)
     .step(0.001)
-    .onChange(function () {
+    .onChange(function() {
       view3D.updateCamera(myState.fov, myState.focalDistance, myState.aperture);
     });
   cameraGui
@@ -201,7 +201,7 @@ function setupGui() {
     .max(5.0)
     .min(0.1)
     .step(0.001)
-    .onChange(function () {
+    .onChange(function() {
       view3D.updateCamera(myState.fov, myState.focalDistance, myState.aperture);
     });
   cameraGui
@@ -209,7 +209,7 @@ function setupGui() {
     .max(90.0)
     .min(0.0)
     .step(0.001)
-    .onChange(function () {
+    .onChange(function() {
       view3D.updateCamera(myState.fov, myState.focalDistance, myState.aperture);
     });
   cameraGui
@@ -217,7 +217,7 @@ function setupGui() {
     .max(1.0)
     .min(0.1)
     .step(0.001)
-    .onChange(function (value) {
+    .onChange(function(value) {
       view3D.updatePixelSamplingRate(value);
     });
 
@@ -227,7 +227,7 @@ function setupGui() {
     .max(1.0)
     .min(0.0)
     .step(0.001)
-    .onChange(function () {
+    .onChange(function() {
       view3D.updateClipRegion(
         myState.volume,
         myState.xmin,
@@ -243,7 +243,7 @@ function setupGui() {
     .max(1.0)
     .min(0.0)
     .step(0.001)
-    .onChange(function () {
+    .onChange(function() {
       view3D.updateClipRegion(
         myState.volume,
         myState.xmin,
@@ -259,7 +259,7 @@ function setupGui() {
     .max(1.0)
     .min(0.0)
     .step(0.001)
-    .onChange(function () {
+    .onChange(function() {
       view3D.updateClipRegion(
         myState.volume,
         myState.xmin,
@@ -275,7 +275,7 @@ function setupGui() {
     .max(1.0)
     .min(0.0)
     .step(0.001)
-    .onChange(function () {
+    .onChange(function() {
       view3D.updateClipRegion(
         myState.volume,
         myState.xmin,
@@ -291,7 +291,7 @@ function setupGui() {
     .max(1.0)
     .min(0.0)
     .step(0.001)
-    .onChange(function () {
+    .onChange(function() {
       view3D.updateClipRegion(
         myState.volume,
         myState.xmin,
@@ -307,7 +307,7 @@ function setupGui() {
     .max(1.0)
     .min(0.0)
     .step(0.001)
-    .onChange(function () {
+    .onChange(function() {
       view3D.updateClipRegion(
         myState.volume,
         myState.xmin,
@@ -323,7 +323,7 @@ function setupGui() {
   lighting
     .addColor(myState, "skyTopColor")
     .name("Sky Top")
-    .onChange(function () {
+    .onChange(function() {
       myState.lights[0].mColorTop = new Vector3(
         (myState.skyTopColor[0] / 255.0) * myState.skyTopIntensity,
         (myState.skyTopColor[1] / 255.0) * myState.skyTopIntensity,
@@ -336,7 +336,7 @@ function setupGui() {
     .max(100.0)
     .min(0.01)
     .step(0.1)
-    .onChange(function () {
+    .onChange(function() {
       myState.lights[0].mColorTop = new Vector3(
         (myState.skyTopColor[0] / 255.0) * myState.skyTopIntensity,
         (myState.skyTopColor[1] / 255.0) * myState.skyTopIntensity,
@@ -347,7 +347,7 @@ function setupGui() {
   lighting
     .addColor(myState, "skyMidColor")
     .name("Sky Mid")
-    .onChange(function () {
+    .onChange(function() {
       myState.lights[0].mColorMiddle = new Vector3(
         (myState.skyMidColor[0] / 255.0) * myState.skyMidIntensity,
         (myState.skyMidColor[1] / 255.0) * myState.skyMidIntensity,
@@ -360,7 +360,7 @@ function setupGui() {
     .max(100.0)
     .min(0.01)
     .step(0.1)
-    .onChange(function () {
+    .onChange(function() {
       myState.lights[0].mColorMiddle = new Vector3(
         (myState.skyMidColor[0] / 255.0) * myState.skyMidIntensity,
         (myState.skyMidColor[1] / 255.0) * myState.skyMidIntensity,
@@ -371,7 +371,7 @@ function setupGui() {
   lighting
     .addColor(myState, "skyBotColor")
     .name("Sky Bottom")
-    .onChange(function () {
+    .onChange(function() {
       myState.lights[0].mColorBottom = new Vector3(
         (myState.skyBotColor[0] / 255.0) * myState.skyBotIntensity,
         (myState.skyBotColor[1] / 255.0) * myState.skyBotIntensity,
@@ -384,7 +384,7 @@ function setupGui() {
     .max(100.0)
     .min(0.01)
     .step(0.1)
-    .onChange(function () {
+    .onChange(function() {
       myState.lights[0].mColorBottom = new Vector3(
         (myState.skyBotColor[0] / 255.0) * myState.skyBotIntensity,
         (myState.skyBotColor[1] / 255.0) * myState.skyBotIntensity,
@@ -397,7 +397,7 @@ function setupGui() {
     .max(10.0)
     .min(0.0)
     .step(0.1)
-    .onChange(function () {
+    .onChange(function() {
       view3D.updateLights(myState.lights);
     });
   lighting
@@ -405,7 +405,7 @@ function setupGui() {
     .max(180.0)
     .min(-180.0)
     .step(1)
-    .onChange(function (value) {
+    .onChange(function(value) {
       myState.lights[1].mTheta = (value * Math.PI) / 180.0;
       view3D.updateLights(myState.lights);
     });
@@ -414,7 +414,7 @@ function setupGui() {
     .max(180.0)
     .min(0.0)
     .step(1)
-    .onChange(function (value) {
+    .onChange(function(value) {
       myState.lights[1].mPhi = (value * Math.PI) / 180.0;
       view3D.updateLights(myState.lights);
     });
@@ -423,7 +423,7 @@ function setupGui() {
     .max(100.0)
     .min(0.01)
     .step(0.1)
-    .onChange(function (value) {
+    .onChange(function(value) {
       myState.lights[1].mWidth = value;
       myState.lights[1].mHeight = value;
       view3D.updateLights(myState.lights);
@@ -433,7 +433,7 @@ function setupGui() {
     .max(1000.0)
     .min(0.01)
     .step(0.1)
-    .onChange(function () {
+    .onChange(function() {
       myState.lights[1].mColor = new Vector3(
         (myState.lightColor[0] / 255.0) * myState.lightIntensity,
         (myState.lightColor[1] / 255.0) * myState.lightIntensity,
@@ -444,7 +444,7 @@ function setupGui() {
   lighting
     .addColor(myState, "lightColor")
     .name("lightColor")
-    .onChange(function () {
+    .onChange(function() {
       myState.lights[1].mColor = new Vector3(
         (myState.lightColor[0] / 255.0) * myState.lightIntensity,
         (myState.lightColor[1] / 255.0) * myState.lightIntensity,
@@ -494,8 +494,8 @@ function showChannelUI(volume: Volume) {
       // first 3 channels for starters
       enabled: i < 3,
       // this doesn't give good results currently but is an example of a per-channel button callback
-      autoIJ: (function (j) {
-        return function () {
+      autoIJ: (function(j) {
+        return function() {
           const lut = volume.getHistogram(j).lutGenerator_auto2();
           // TODO: get a proper transfer function editor
           // const lut = { lut: makeColorGradient([
@@ -510,32 +510,32 @@ function showChannelUI(volume: Volume) {
         };
       })(i),
       // this doesn't give good results currently but is an example of a per-channel button callback
-      auto0: (function (j) {
-        return function () {
+      auto0: (function(j) {
+        return function() {
           const lut = volume.getHistogram(j).lutGenerator_auto();
           volume.setLut(j, lut.lut);
           view3D.updateLuts(volume);
         };
       })(i),
       // this doesn't give good results currently but is an example of a per-channel button callback
-      bestFit: (function (j) {
-        return function () {
+      bestFit: (function(j) {
+        return function() {
           const lut = volume.getHistogram(j).lutGenerator_bestFit();
           volume.setLut(j, lut.lut);
           view3D.updateLuts(volume);
         };
       })(i),
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      pct50_98: (function (j) {
-        return function () {
+      pct50_98: (function(j) {
+        return function() {
           const lut = volume.getHistogram(j).lutGenerator_percentiles(0.5, 0.998);
           volume.setLut(j, lut.lut);
           view3D.updateLuts(volume);
         };
       })(i),
       colorizeEnabled: false,
-      colorize: (function (j) {
-        return function () {
+      colorize: (function(j) {
+        return function() {
           const lut = volume.getHistogram(j).lutGenerator_labelColors();
           volume.setColorPalette(j, lut.lut);
           myState.channelGui[j].colorizeEnabled = !myState.channelGui[j].colorizeEnabled;
@@ -553,16 +553,16 @@ function showChannelUI(volume: Volume) {
     const f = gui.addFolder("Channel " + myState.infoObj.channel_names[i]);
     myState.channelFolderNames.push("Channel " + myState.infoObj.channel_names[i]);
     f.add(myState.channelGui[i], "enabled").onChange(
-      (function (j) {
-        return function (value) {
+      (function(j) {
+        return function(value) {
           view3D.setVolumeChannelEnabled(volume, j, value ? true : false);
           view3D.updateActiveChannels(volume);
         };
       })(i)
     );
     f.add(myState.channelGui[i], "isosurface").onChange(
-      (function (j) {
-        return function (value) {
+      (function(j) {
+        return function(value) {
           if (value) {
             view3D.createIsosurface(volume, j, myState.channelGui[j].isovalue, 1.0);
           } else {
@@ -576,8 +576,8 @@ function showChannelUI(volume: Volume) {
       .min(0)
       .step(1)
       .onChange(
-        (function (j) {
-          return function (value) {
+        (function(j) {
+          return function(value) {
             view3D.updateIsosurface(volume, j, value);
           };
         })(i)
@@ -586,8 +586,8 @@ function showChannelUI(volume: Volume) {
     f.addColor(myState.channelGui[i], "colorD")
       .name("Diffuse")
       .onChange(
-        (function (j) {
-          return function () {
+        (function(j) {
+          return function() {
             view3D.updateChannelMaterial(
               volume,
               j,
@@ -603,8 +603,8 @@ function showChannelUI(volume: Volume) {
     f.addColor(myState.channelGui[i], "colorS")
       .name("Specular")
       .onChange(
-        (function (j) {
-          return function () {
+        (function(j) {
+          return function() {
             view3D.updateChannelMaterial(
               volume,
               j,
@@ -620,8 +620,8 @@ function showChannelUI(volume: Volume) {
     f.addColor(myState.channelGui[i], "colorE")
       .name("Emissive")
       .onChange(
-        (function (j) {
-          return function () {
+        (function(j) {
+          return function() {
             view3D.updateChannelMaterial(
               volume,
               j,
@@ -639,8 +639,8 @@ function showChannelUI(volume: Volume) {
       .min(0.0)
       .step(0.001)
       .onChange(
-        (function (j) {
-          return function (value) {
+        (function(j) {
+          return function(value) {
             volume.getChannel(j).lutGenerator_windowLevel(value, myState.channelGui[j].level);
             view3D.updateLuts(volume);
           };
@@ -652,8 +652,8 @@ function showChannelUI(volume: Volume) {
       .min(0.0)
       .step(0.001)
       .onChange(
-        (function (j) {
-          return function (value) {
+        (function(j) {
+          return function(value) {
             volume.getChannel(j).lutGenerator_windowLevel(myState.channelGui[j].window, value);
             view3D.updateLuts(volume);
           };
@@ -668,8 +668,8 @@ function showChannelUI(volume: Volume) {
       .max(1.0)
       .min(0.0)
       .onChange(
-        (function (j) {
-          return function (value) {
+        (function(j) {
+          return function(value) {
             if (myState.channelGui[j].colorizeEnabled) {
               volume.setColorPaletteAlpha(j, value);
               view3D.updateLuts(volume);
@@ -681,8 +681,8 @@ function showChannelUI(volume: Volume) {
       .max(100.0)
       .min(0.0)
       .onChange(
-        (function (j) {
-          return function () {
+        (function(j) {
+          return function() {
             view3D.updateChannelMaterial(
               volume,
               j,
@@ -780,14 +780,14 @@ function cacheTimeSeriesImageData(jsonData, frameNumber) {
 
 function fetchImage(url, isTimeSeries = false, frameNumber = 0) {
   fetch(url)
-    .then(function (response) {
+    .then(function(response) {
       return response.json();
     })
-    .then(function (myJson) {
+    .then(function(myJson) {
       if (isTimeSeries) {
         // if you need to adjust image paths prior to download,
         // now is the time to do it:
-        myJson.images.forEach(function (element) {
+        myJson.images.forEach(function(element) {
           element.name = "http://dev-aics-dtp-001.corp.alleninstitute.org/dan-data/" + element.name;
         });
 
@@ -1034,7 +1034,6 @@ function main() {
     }
 
     myState.boundingBoxColor = hexToRgb((event.target as HTMLInputElement)?.value, myState.boundingBoxColor);
-    //console.log((event.target as HTMLInputElement)?.value);
     view3D.setBoundingBoxColor(myState.volume, myState.boundingBoxColor);
   });
 
@@ -1085,7 +1084,7 @@ function main() {
   });
   const counterSpan = document.getElementById("counter");
   if (counterSpan) {
-    view3D.setRenderUpdateListener((count) => {
+    view3D.setRenderUpdateListener(count => {
       counterSpan.innerHTML = "" + count;
     });
   }
@@ -1101,7 +1100,7 @@ function main() {
   }
   const screenshotBtn = document.getElementById("screenshotBtn");
   screenshotBtn?.addEventListener("click", () => {
-    view3D.capture((dataUrl) => {
+    view3D.capture(dataUrl => {
       const anchor = document.createElement("a");
       anchor.href = dataUrl;
       anchor.download = "screenshot.png";

--- a/public/index.ts
+++ b/public/index.ts
@@ -65,6 +65,7 @@ const myState: State = {
   isAligned: true,
 
   showBoundingBox: false,
+  boundingBoxColor: [255, 255, 0],
   flipX: 1,
   flipY: 1,
   flipZ: 1,
@@ -1022,6 +1023,21 @@ function main() {
     myState.showBoundingBox = !myState.showBoundingBox;
     view3D.setShowBoundingBox(myState.volume, myState.showBoundingBox);
   });
+  const boundsColorBtn = document.getElementById("boundingBoxColor");
+  boundsColorBtn?.addEventListener("change", (event: Event) => {
+    // convert value to rgb array
+    function hexToRgb(hex, last: [number, number, number]): [number, number, number] {
+      const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+      return result
+        ? [parseInt(result[1], 16) / 255.0, parseInt(result[2], 16) / 255.0, parseInt(result[3], 16) / 255.0]
+        : last;
+    }
+
+    myState.boundingBoxColor = hexToRgb((event.target as HTMLInputElement)?.value, myState.boundingBoxColor);
+    //console.log((event.target as HTMLInputElement)?.value);
+    view3D.setBoundingBoxColor(myState.volume, myState.boundingBoxColor);
+  });
+
   const flipXBtn = document.getElementById("flipXBtn");
   flipXBtn?.addEventListener("click", () => {
     myState.flipX *= -1;

--- a/public/types.ts
+++ b/public/types.ts
@@ -48,6 +48,7 @@ export interface State {
   isAxisShowing: boolean;
   isAligned: boolean;
 
+  showBoundingBox: boolean;
   flipX: number;
   flipY: number;
   flipZ: number;
@@ -75,4 +76,5 @@ interface ChannelGuiOptions {
   colorizeEnabled: boolean;
   colorize: (channelNum: number) => void;
   colorizeAlpha: number;
+}
 }

--- a/public/types.ts
+++ b/public/types.ts
@@ -49,6 +49,8 @@ export interface State {
   isAligned: boolean;
 
   showBoundingBox: boolean;
+  boundingBoxColor: [number, number, number];
+
   flipX: number;
   flipY: number;
   flipZ: number;

--- a/public/types.ts
+++ b/public/types.ts
@@ -69,7 +69,7 @@ interface ChannelGuiOptions {
   glossiness: number;
   isovalue: number;
   isosurface: boolean;
-  enabled: boolean,
+  enabled: boolean;
   autoIJ: (channelNum: number) => void;
   auto0: (channelNum: number) => void;
   bestFit: (channelNum: number) => void;
@@ -78,5 +78,4 @@ interface ChannelGuiOptions {
   colorizeEnabled: boolean;
   colorize: (channelNum: number) => void;
   colorizeAlpha: number;
-}
 }

--- a/src/MeshVolume.ts
+++ b/src/MeshVolume.ts
@@ -103,7 +103,7 @@ export default class MeshVolume {
   }
 
   setTranslation(vec3xyz: Vector3): void {
-    this.meshRoot.position.copy(vec3xyz);
+    this.meshPivot.position.copy(vec3xyz);
   }
 
   setRotation(eulerXYZ: Euler): void {

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -402,8 +402,8 @@ export default class PathTracedVolume {
     // apply volume translation and rotation:
     // rotate camera.up, camera.direction, and camera position by inverse of volume's modelview
     const m = new Matrix4().makeRotationFromQuaternion(new Quaternion().setFromEuler(this.rotation).invert());
-    mypos.applyMatrix4(m);
     mypos.sub(this.translation);
+    mypos.applyMatrix4(m);
     myup.applyMatrix4(m);
     mydir.applyMatrix4(m);
 

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -803,6 +803,7 @@ export default class PathTracedVolume {
     }
   }
 
+  // 0..1 ranges as input
   updateClipRegion(xmin: number, xmax: number, ymin: number, ymax: number, zmin: number, zmax: number): void {
     this.bounds = {
       bmin: new Vector3(xmin - 0.5, ymin - 0.5, zmin - 0.5),

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -354,6 +354,10 @@ export default class PathTracedVolume {
     // this.visible = isVisible;
   }
 
+  public setShowBoundingBox(_showBoundingBox: boolean): void {
+    // TODO: NOT IMPLEMENTED YET
+  }
+
   public doRender(canvas: ThreeJsPanel): void {
     if (!this.volumeTexture) {
       return;

--- a/src/PathTracedVolume.ts
+++ b/src/PathTracedVolume.ts
@@ -358,6 +358,10 @@ export default class PathTracedVolume {
     // TODO: NOT IMPLEMENTED YET
   }
 
+  public setBoundingBoxColor(_color: [number, number, number]): void {
+    // TODO: NOT IMPLEMENTED YET
+  }
+
   public doRender(canvas: ThreeJsPanel): void {
     if (!this.volumeTexture) {
       return;

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -3,6 +3,7 @@ import {
   Box3Helper,
   BoxGeometry,
   BufferGeometry,
+  Color,
   Euler,
   Group,
   Material,
@@ -50,7 +51,7 @@ export default class RayMarchedAtlasVolume {
     this.cubeMesh = new Mesh(this.cube);
     this.cubeMesh.name = "Volume";
 
-    this.boxHelper = new Box3Helper(new Box3(this.bounds.bmin, this.bounds.bmax), 0xffff00);
+    this.boxHelper = new Box3Helper(new Box3(this.bounds.bmin, this.bounds.bmax), new Color(0xffff00));
     this.boxHelper.updateMatrixWorld();
     this.boxHelper.visible = false;
 

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -1,15 +1,16 @@
 import {
-  BoxHelper,
+  Box3,
+  Box3Helper,
+  BoxGeometry,
+  BufferGeometry,
   Euler,
+  Group,
+  Material,
+  Matrix4,
+  Mesh,
+  ShaderMaterial,
   Vector2,
   Vector3,
-  Group,
-  BoxGeometry,
-  Mesh,
-  Material,
-  ShaderMaterial,
-  Matrix4,
-  BufferGeometry,
 } from "three";
 
 import FusedChannelData from "./FusedChannelData";
@@ -29,7 +30,7 @@ export default class RayMarchedAtlasVolume {
   public bounds: Bounds;
   private cube: BoxGeometry;
   private cubeMesh: Mesh<BufferGeometry, Material>;
-  private boxHelper: BoxHelper;
+  private boxHelper: Box3Helper;
   private cubeTransformNode: Group;
   private uniforms: typeof rayMarchingShaderUniforms;
   private channelData: FusedChannelData;
@@ -49,13 +50,14 @@ export default class RayMarchedAtlasVolume {
     this.cubeMesh = new Mesh(this.cube);
     this.cubeMesh.name = "Volume";
 
-    this.boxHelper = new BoxHelper(this.cubeMesh, 0xffff00);
+    this.boxHelper = new Box3Helper(new Box3(this.bounds.bmin, this.bounds.bmax), 0xffff00);
+    this.boxHelper.updateMatrixWorld();
+    this.boxHelper.visible = false;
 
     this.cubeTransformNode = new Group();
     this.cubeTransformNode.name = "VolumeContainerNode";
-    // TODO: when bounding box UX is determined,
-    // uncomment the following line to show the box
-    //this.cubeTransformNode.add(this.boxHelper);
+
+    this.cubeTransformNode.add(this.boxHelper);
     this.cubeTransformNode.add(this.cubeMesh);
 
     this.uniforms = rayMarchingShaderUniforms;
@@ -69,14 +71,17 @@ export default class RayMarchedAtlasVolume {
       vertexShader: vtxsrc,
       fragmentShader: fgmtsrc,
       transparent: true,
-      depthTest: false,
+      depthTest: true,
+      depthWrite: false,
     });
+
     this.cubeMesh.material = threeMaterial;
 
     this.setUniform("ATLAS_X", volume.imageInfo.cols);
     this.setUniform("ATLAS_Y", volume.imageInfo.rows);
     this.setUniform("textureRes", new Vector2(volume.imageInfo.atlas_width, volume.imageInfo.atlas_height));
     this.setUniform("SLICES", volume.z);
+    this.setScale(this.scale);
 
     this.channelData = new FusedChannelData(volume.imageInfo.atlas_width, volume.imageInfo.atlas_height);
     // tell channelData about the channels that are already present, one at a time.
@@ -96,6 +101,11 @@ export default class RayMarchedAtlasVolume {
 
   public setVisible(isVisible: boolean): void {
     this.cubeMesh.visible = isVisible;
+    // note that this does not affect bounding box visibility
+  }
+
+  public setShowBoundingBox(showBoundingBox: boolean): void {
+    this.boxHelper.visible = showBoundingBox;
   }
 
   public doRender(canvas: ThreeJsPanel): void {
@@ -103,8 +113,7 @@ export default class RayMarchedAtlasVolume {
       return;
     }
 
-    this.cubeMesh.updateMatrixWorld(true);
-    this.boxHelper.update();
+    this.cubeTransformNode.updateMatrixWorld(true);
 
     const mvm = new Matrix4();
     mvm.multiplyMatrices(canvas.camera.matrixWorldInverse, this.cubeMesh.matrixWorld);
@@ -112,17 +121,6 @@ export default class RayMarchedAtlasVolume {
     mi.copy(mvm).invert();
 
     this.setUniform("inverseModelViewMatrix", mi);
-
-    const isVR = canvas.isVR();
-    if (isVR) {
-      this.cubeMesh.material.depthWrite = true;
-      this.cubeMesh.material.transparent = false;
-      this.cubeMesh.material.depthTest = true;
-    } else {
-      this.cubeMesh.material.depthWrite = false;
-      this.cubeMesh.material.transparent = true;
-      this.cubeMesh.material.depthTest = false;
-    }
   }
 
   public get3dObject(): Group {
@@ -138,6 +136,10 @@ export default class RayMarchedAtlasVolume {
 
     this.cubeMesh.scale.copy(new Vector3(scale.x, scale.y, scale.z));
     this.setUniform("volumeScale", scale);
+    this.boxHelper.box.set(
+      new Vector3(-0.5 * scale.x, -0.5 * scale.y, -0.5 * scale.z),
+      new Vector3(0.5 * scale.x, 0.5 * scale.y, 0.5 * scale.z)
+    );
   }
 
   public setRayStepSizes(_primary: number, _secondary: number): void {
@@ -145,7 +147,7 @@ export default class RayMarchedAtlasVolume {
   }
 
   public setTranslation(vec3xyz: Vector3): void {
-    this.cubeMesh.position.copy(vec3xyz);
+    this.cubeTransformNode.position.copy(vec3xyz);
   }
 
   public setRotation(eulerXYZ: Euler): void {

--- a/src/RayMarchedAtlasVolume.ts
+++ b/src/RayMarchedAtlasVolume.ts
@@ -6,6 +6,7 @@ import {
   Color,
   Euler,
   Group,
+  LineBasicMaterial,
   Material,
   Matrix4,
   Mesh,
@@ -107,6 +108,14 @@ export default class RayMarchedAtlasVolume {
 
   public setShowBoundingBox(showBoundingBox: boolean): void {
     this.boxHelper.visible = showBoundingBox;
+  }
+
+  public setBoundingBoxColor(color: [number, number, number]): void {
+    // note this material update is supposed to be a hidden implementation detail
+    // but I didn't want to re-create a whole boxHelper again.
+    // I could also create a new LineBasicMaterial but that would also rely on knowledge
+    // that Box3Helper expects that type.
+    (this.boxHelper.material as LineBasicMaterial).color = new Color(color[0], color[1], color[2]);
   }
 
   public doRender(canvas: ThreeJsPanel): void {

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -232,6 +232,13 @@ export class View3d {
     this.redraw();
   }
 
+  setShowBoundingBox(volume: Volume, showBoundingBox: boolean): void {
+    if (this.image) {
+      this.image.setShowBoundingBox(showBoundingBox);
+    }
+    this.redraw();
+  }
+
   /**
    * If an isosurface is not already created, then create one.  Otherwise change the isovalue of the existing isosurface.
    * @param {Object} volume
@@ -743,7 +750,7 @@ export class View3d {
 
     this.volumeRenderMode = mode;
     if (this.image) {
-      if (mode === RENDERMODE_PATHTRACE && this.canvas3d.hasWebGL2 && !this.canvas3d.isVR()) {
+      if (mode === RENDERMODE_PATHTRACE && this.canvas3d.hasWebGL2) {
         this.image.setVolumeRendering(true);
         this.image.updateLights(this.lights);
         // pathtrace is a continuous rendering mode

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -239,6 +239,13 @@ export class View3d {
     this.redraw();
   }
 
+  setBoundingBoxColor(volume: Volume, color: [number, number, number]): void {
+    if (this.image) {
+      this.image.setBoundingBoxColor(color);
+    }
+    this.redraw();
+  }
+
   /**
    * If an isosurface is not already created, then create one.  Otherwise change the isovalue of the existing isosurface.
    * @param {Object} volume

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -271,11 +271,11 @@ export default class VolumeDrawable {
     this.meshVolume.setResolution(x, y);
   }
 
-  // Set clipping range (between 0 and 1) for a given axis.
+  // Set clipping range (between -0.5 and 0.5) for a given axis.
   // Calling this allows the rendering to compensate for changes in thickness in orthographic views that affect how bright the volume is.
   // @param {number} axis 0, 1, or 2 for x, y, or z axis
-  // @param {number} minval 0..1, should be less than maxval
-  // @param {number} maxval 0..1, should be greater than minval
+  // @param {number} minval -0.5..0.5, should be less than maxval
+  // @param {number} maxval -0.5..0.5, should be greater than minval
   // @param {boolean} isOrthoAxis is this an orthographic projection or just a clipping of the range for perspective view
   setAxisClip(axis: number, minval: number, maxval: number, isOrthoAxis?: boolean): void {
     this.bounds.bmax[axis] = maxval;
@@ -583,7 +583,10 @@ export default class VolumeDrawable {
     this.PT && this.pathTracedVolume && this.pathTracedVolume.updateCamera(fov, focalDistance, apertureSize);
   }
 
+  // values are in 0..1 range
   updateClipRegion(xmin: number, xmax: number, ymin: number, ymax: number, zmin: number, zmax: number): void {
+    this.bounds.bmin = new Vector3(xmin - 0.5, ymin - 0.5, zmin - 0.5);
+    this.bounds.bmax = new Vector3(xmax - 0.5, ymax - 0.5, zmax - 0.5);
     this.volumeRendering.updateClipRegion(xmin, xmax, ymin, ymax, zmin, zmax);
     this.meshVolume.updateClipRegion(xmin, xmax, ymin, ymax, zmin, zmax);
   }
@@ -647,8 +650,18 @@ export default class VolumeDrawable {
     this.setAxisClip(0, this.bounds.bmin.x, this.bounds.bmax.x);
     this.setAxisClip(1, this.bounds.bmin.y, this.bounds.bmax.y);
     this.setAxisClip(2, this.bounds.bmin.z, this.bounds.bmax.z);
-
+    this.updateClipRegion(
+      this.bounds.bmin.x + 0.5,
+      this.bounds.bmax.x + 0.5,
+      this.bounds.bmin.y + 0.5,
+      this.bounds.bmax.y + 0.5,
+      this.bounds.bmin.z + 0.5,
+      this.bounds.bmax.z + 0.5
+    );
     this.setRayStepSizes(this.primaryRayStepSize, this.secondaryRayStepSize);
+
+    this.setShowBoundingBox(this.showBoundingBox);
+    this.setBoundingBoxColor(this.boundingBoxColor);
 
     // add new 3d object to scene
     !this.PT && this.sceneRoot.add(this.meshVolume.get3dObject());

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -37,6 +37,7 @@ export default class VolumeDrawable {
   private primaryRayStepSize: number;
   private secondaryRayStepSize: number;
   private showBoundingBox: boolean;
+  private boundingBoxColor: [number, number, number];
 
   // these two should never coexist simultaneously. always one or the other is present
   // a polymorphic interface implementation might be a better way to deal with this.
@@ -79,6 +80,7 @@ export default class VolumeDrawable {
     this.brightness = 0;
 
     this.showBoundingBox = false;
+    this.boundingBoxColor = [1.0, 1.0, 0.0];
 
     this.channelColors = this.volume.channel_colors_default.slice();
 
@@ -179,6 +181,9 @@ export default class VolumeDrawable {
     }
     if (options.showBoundingBox !== undefined) {
       this.setShowBoundingBox(options.showBoundingBox);
+    }
+    if (options.boundingBoxColor !== undefined) {
+      this.setBoundingBoxColor(options.boundingBoxColor);
     }
 
     if (options.channels !== undefined) {
@@ -547,6 +552,11 @@ export default class VolumeDrawable {
   setShowBoundingBox(showBoundingBox: boolean): void {
     this.showBoundingBox = showBoundingBox;
     this.volumeRendering.setShowBoundingBox(showBoundingBox);
+  }
+
+  setBoundingBoxColor(color: [number, number, number]): void {
+    this.boundingBoxColor = color;
+    this.volumeRendering.setBoundingBoxColor(color);
   }
 
   getIntensity(c: number, x: number, y: number, z: number): number {

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -36,6 +36,7 @@ export default class VolumeDrawable {
   private meshVolume: MeshVolume;
   private primaryRayStepSize: number;
   private secondaryRayStepSize: number;
+  private showBoundingBox: boolean;
 
   // these two should never coexist simultaneously. always one or the other is present
   // a polymorphic interface implementation might be a better way to deal with this.
@@ -76,6 +77,8 @@ export default class VolumeDrawable {
     // TODO verify that these are reasonable
     this.density = 0;
     this.brightness = 0;
+
+    this.showBoundingBox = false;
 
     this.channelColors = this.volume.channel_colors_default.slice();
 
@@ -171,11 +174,11 @@ export default class VolumeDrawable {
     if (options.renderMode !== undefined) {
       this.setVolumeRendering(!!options.renderMode);
     }
-    if (
-      options.primaryRayStepSize !== undefined ||
-      options.secondaryRayStepSize !== undefined
-    ) {
+    if (options.primaryRayStepSize !== undefined || options.secondaryRayStepSize !== undefined) {
       this.setRayStepSizes(options.primaryRayStepSize, options.secondaryRayStepSize);
+    }
+    if (options.showBoundingBox !== undefined) {
+      this.setShowBoundingBox(options.showBoundingBox);
     }
 
     if (options.channels !== undefined) {
@@ -317,14 +320,6 @@ export default class VolumeDrawable {
     canvas.camera.updateMatrixWorld(true);
 
     canvas.camera.matrixWorldInverse.copy(canvas.camera.matrixWorld).invert();
-
-    const isVR = canvas.isVR();
-    if (isVR) {
-      // raise volume drawable to about 1 meter.
-      this.sceneRoot.position.y = 1.0;
-    } else {
-      this.sceneRoot.position.y = 0.0;
-    }
 
     // TODO confirm sequence
     this.volumeRendering.doRender(canvas);
@@ -547,6 +542,11 @@ export default class VolumeDrawable {
   setMaskAlpha(maskAlpha: number): void {
     this.maskAlpha = maskAlpha;
     this.volumeRendering.setMaskAlpha(maskAlpha);
+  }
+
+  setShowBoundingBox(showBoundingBox: boolean): void {
+    this.showBoundingBox = showBoundingBox;
+    this.volumeRendering.setShowBoundingBox(showBoundingBox);
   }
 
   getIntensity(c: number, x: number, y: number, z: number): number {

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,7 @@ export interface VolumeChannelDisplayOptions {
  * @property {number} primaryRayStepSize in voxels
  * @property {number} secondaryRayStepSize in voxels
  * @property {boolean} showBoundingBox true or false
+ * @property {Array.<number>} boundingBoxColor r,g,b for bounding box lines
  * @example let options = {
    };
  */
@@ -74,6 +75,7 @@ export interface VolumeDisplayOptions {
   primaryRayStepSize?: number;
   secondaryRayStepSize?: number;
   showBoundingBox?: boolean;
+  boundingBoxColor?: [number, number, number];
 }
 
 export const isOrthographicCamera = (def: Camera): def is OrthographicCamera =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,7 @@ export interface VolumeChannelDisplayOptions {
  * @property {Array.<number>} gamma [min, max, scale]
  * @property {number} primaryRayStepSize in voxels
  * @property {number} secondaryRayStepSize in voxels
+ * @property {boolean} showBoundingBox true or false
  * @example let options = {
    };
  */
@@ -72,6 +73,7 @@ export interface VolumeDisplayOptions {
   gamma?: [number, number, number];
   primaryRayStepSize?: number;
   secondaryRayStepSize?: number;
+  showBoundingBox?: boolean;
 }
 
 export const isOrthographicCamera = (def: Camera): def is OrthographicCamera =>


### PR DESCRIPTION
Add api for showing bounding box lines and setting their color.

This remains unimplemented in Path Trace mode, and the bounds will not show up.

In order to position them correctly without breaking the "align" functionality, I had to modify the way transforms are applied to the volume data.  Some changes are to ensure that all three of path trace, ray march, and isosurface meshes are displayed with the same transforms. 

Lastly, there is a bonus bug fix for switching between path trace and ray march modes when clipping is applied.  (Currently if you apply axis clipping and then switch modes, your clipping gets reset.)

![AICS 3D Volume Viewer 2021-11-05 14-39-21](https://user-images.githubusercontent.com/2193409/140581697-53688e1c-f791-47ce-bd5e-80c486ad0638.png)


