### PR TITLE
reinstate multithreading

### DIFF
--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -62,7 +62,7 @@ export default class FusedChannelData {
     this.maskChannelIndex = 0;
 
     // force single threaded use even if webworkers are available
-    this.useSingleThread = true;
+    this.useSingleThread = false;
 
     // thread control
     this.fuseWorkersWorking = 0;


### PR DESCRIPTION
Because of some prototyping work, a flag was set that just killed performance in this viewer.  This change reinstates the faster multithreaded mode in production at the cost of breaking the experimental functionality.
