### PR TITLE
Read z size for non-OME TIFFs

### DIFF
--- a/src/loaders/TiffLoader.ts
+++ b/src/loaders/TiffLoader.ts
@@ -168,9 +168,11 @@ class TiffLoader extends ThreadableVolumeLoader {
           } catch (_e) {}
         }
 
+        // if `ImageDescription` is valid JSON with a `shape` field, we expect it to be an array of [t?, c?, z?, y, x].
         this.dims.sizex = shape[shape.length - 1] ?? image.getWidth();
         this.dims.sizey = shape[shape.length - 2] ?? image.getHeight();
         this.dims.sizez = shape[shape.length - 3] ?? (await tiff.getImageCount());
+
         // TODO this is a big hack/assumption about only loading multi-source tiffs that are not OMETIFF.
         // We really have to check each url in the array for sizec to get the total number of channels
         // See combinedNumChannels in ImageInfo below.


### PR DESCRIPTION
Review time: tiny (<5min)

#327 added very basic support for TIFFs that don't conform to the OME metadata spec. But the images that motivated that work were 2D, so I missed how to properly read Z dimensions from this type of image. This is a 1-line change that does that.
