### PR TITLE
feat: Support selection of multiple IDs, multiple colors

### DIFF
--- a/public/colorizer.ts
+++ b/public/colorizer.ts
@@ -1,11 +1,5 @@
 import { Color, DataTexture, FloatType, RGBAFormat, RedFormat, RedIntegerFormat, LinearFilter, UnsignedByteType } from "three";
-
-function getSquarestTextureDimensions(size: number): [number, number] {
-  const width = Math.ceil(Math.sqrt(size));
-  const height = Math.ceil(size / width);
-
-  return [width, height];
-}
+import { getSquarestTextureDimensions } from "../src/utils/texture_utils";
 
 function loadColormap(colorStops: string[]): DataTexture {
   const colorColorStops = colorStops.map((color) => new Color(color));

--- a/public/index.ts
+++ b/public/index.ts
@@ -1193,6 +1193,8 @@ function getStateColorizeFeature(): ColorizeFeature | null {
       outlineColor: new Color(0xffffff),
       outlineAlpha: 1.0,
       outlierColor: new Color(0x444444),
+      outlinePalette: colormap,
+      useOutlinePalette: false,
       outOfRangeColor: new Color(0x444444),
       outlierDrawMode: 0,
       outOfRangeDrawMode: 0,

--- a/public/index.ts
+++ b/public/index.ts
@@ -1194,6 +1194,8 @@ function getStateColorizeFeature(): ColorizeFeature | null {
       outlineAlpha: 1.0,
       outlierColor: new Color(0x444444),
       outlinePalette: colormap,
+      innerOutlineColor: new Color(0x000000),
+      innerOutlineThickness: 0.0,
       useOutlinePalette: false,
       outOfRangeColor: new Color(0x444444),
       outlierDrawMode: 0,

--- a/src/ContourPass.ts
+++ b/src/ContourPass.ts
@@ -166,6 +166,7 @@ export default class ContourPass {
     }
     this.selectedIdsTexture = new DataTexture(paddedSelectedIds, width, height, RedIntegerFormat, UnsignedByteType);
     this.selectedIdsTexture.internalFormat = "R8UI";
+    this.selectedIdsTexture.unpackAlignment = 1;
     this.selectedIdsTexture.needsUpdate = true;
     this.pass.material.uniforms.selectedIds.value = this.selectedIdsTexture;
   }

--- a/src/ContourPass.ts
+++ b/src/ContourPass.ts
@@ -98,10 +98,11 @@ export default class ContourPass {
   }
 
   /**
-   * Optional inner outline shown when using outline palettes for better contrast.
+   * Optional inner outline shown for better contrast, specified in integer
+   * pixels. Disabled if `thicknessPx` is 0.
    */
   public setInnerOutlineThickness(thicknessPx: number): void {
-    this.pass.material.uniforms.innerOutlineThickness.value = Math.floor(thicknessPx);
+    this.pass.material.uniforms.innerOutlineThickness.value = Math.floor(Math.max(0, thicknessPx));
   }
 
   private syncGlobalIdLookup(): void {
@@ -151,20 +152,21 @@ export default class ContourPass {
   }
 
   /**
-   * Sets the lookup table that maps from an ID to whether the ID is
-   * selected or not.
+   * Sets the lookup table that maps from an ID to whether the ID is selected or
+   * not.
    *
    * For some ID `i`, if `selectedIds[i] > 0`, the ID is selected. When
-   * `useOutlinePalette` is true, the value of `selectedIds[i]` is used
-   * as the index of the outline color in the outline palette.
+   * `useOutlinePalette` is true, `selectedIds[i] - 1` is the index of the
+   * outline color in the outline palette.
    *
-   * By default, the ID is a local (pixel) ID. If a global ID
-   * lookup has been set (`setGlobalIdLookup`), the ID is parsed as a global ID.
+   * By default, the ID is a local (pixel) ID. If a global ID lookup has been
+   * set (`setGlobalIdLookup`), the ID is parsed as a global ID.
    */
   public setSelectedIdLut(selectedIds: Uint8Array) {
     if (this.selectedIdsTexture) {
       this.selectedIdsTexture.dispose();
     }
+    // Pack into square texture
     const [width, height] = getSquarestTextureDimensions(selectedIds.length);
     let paddedSelectedIds = selectedIds;
     if (selectedIds.length < width * height) {

--- a/src/ContourPass.ts
+++ b/src/ContourPass.ts
@@ -43,11 +43,15 @@ type ContourUniforms = {
 const makeDefaultUniforms = (): ContourUniforms => {
   // RGBA float texture for pick buffer
   const pickBufferTex = new DataTexture(new Float32Array([0, 0, 0, 0]), 1, 1, RGBAFormat, FloatType);
+  pickBufferTex.internalFormat = "RGBA32F";
+  pickBufferTex.needsUpdate = true;
   // R32UI texture for local ID to global ID lookup
   const localIdToGlobalId = new DataTexture(new Uint32Array([0]), 1, 1, RedIntegerFormat, UnsignedIntType);
+  localIdToGlobalId.internalFormat = "R32UI";
   localIdToGlobalId.needsUpdate = true;
   // RGBA float texture for outline palette
   const outlinePaletteTex = new DataTexture(new Float32Array([1, 1, 1, 0]), 1, 1, RGBAFormat, FloatType);
+  outlinePaletteTex.internalFormat = "RGBA32F";
   outlinePaletteTex.needsUpdate = true;
   // R8UI texture for selected IDs
   const selectedIds = new DataTexture(new Uint8Array([0]), 1, 1, RedIntegerFormat, UnsignedByteType);

--- a/src/ContourPass.ts
+++ b/src/ContourPass.ts
@@ -3,7 +3,6 @@ import {
   DataTexture,
   FloatType,
   IUniform,
-  RedFormat,
   RedIntegerFormat,
   RGBAFormat,
   Texture,
@@ -23,12 +22,6 @@ import { getSquarestTextureDimensions } from "./utils/texture_utils.js";
 type ContourUniforms = {
   // Base image (pick buffer)
   pickBuffer: IUniform<Texture>;
-  // ID information
-  selectedId: IUniform<number>;
-  selectedIds: IUniform<Texture>;
-  useGlobalIdLookup: IUniform<boolean>;
-  localIdToGlobalId: IUniform<Texture>;
-  localIdOffset: IUniform<number>;
   // Outline style
   outlineThickness: IUniform<number>;
   innerOutlineThickness: IUniform<number>;
@@ -37,15 +30,21 @@ type ContourUniforms = {
   outlinePalette: IUniform<Texture>;
   useOutlinePalette: IUniform<boolean>;
   outlineAlpha: IUniform<number>;
+  // ID information
+  selectedId: IUniform<number>;
+  selectedIds: IUniform<Texture>;
+  useGlobalIdLookup: IUniform<boolean>;
+  localIdToGlobalId: IUniform<Texture>;
+  localIdOffset: IUniform<number>;
 
   devicePixelRatio: IUniform<number>;
 };
 
 const makeDefaultUniforms = (): ContourUniforms => {
-  const pickBufferTex = new DataTexture(new Float32Array([1, 0, 0, 0]), 1, 1, RGBAFormat, FloatType);
+  const pickBufferTex = new DataTexture(new Float32Array([0, 0, 0, 0]), 1, 1, RGBAFormat, FloatType);
   const localIdToGlobalId = new DataTexture(new Uint32Array([0]), 1, 1, RedIntegerFormat, UnsignedIntType);
   localIdToGlobalId.needsUpdate = true;
-  const outlinePaletteTex = new DataTexture(new Float32Array([1, 0, 0, 0]), 1, 1, RGBAFormat, FloatType);
+  const outlinePaletteTex = new DataTexture(new Float32Array([1, 1, 1, 0]), 1, 1, RGBAFormat, FloatType);
   outlinePaletteTex.needsUpdate = true;
   const selectedIds = new DataTexture(new Uint8Array([0]), 1, 1, RedIntegerFormat, UnsignedByteType);
   selectedIds.internalFormat = "R8UI";

--- a/src/ContourPass.ts
+++ b/src/ContourPass.ts
@@ -57,7 +57,7 @@ const makeDefaultUniforms = (): ContourUniforms => {
     outlineThickness: new Uniform(2.0),
     innerOutlineThickness: new Uniform(2.0),
     useOutlinePalette: new Uniform(false),
-    backgroundColor: new Uniform(new Color(0, 0, 0)),
+    backgroundColor: new Uniform(new Color(1, 1, 1)),
     outlineColor: new Uniform(new Color(1, 0, 1)),
     outlineAlpha: new Uniform(1.0),
     outlinePalette: new Uniform(outlinePaletteTex),
@@ -151,8 +151,6 @@ export default class ContourPass {
       paddedSelectedIds = new Uint8Array(width * height);
       paddedSelectedIds.set(selectedIds);
     }
-    console.log("New selected IDs texture size:", paddedSelectedIds.length, width, height);
-
     this.selectedIdsTexture = new DataTexture(paddedSelectedIds, width, height, RedIntegerFormat, UnsignedByteType);
     this.selectedIdsTexture.internalFormat = "R8UI";
     this.selectedIdsTexture.needsUpdate = true;
@@ -164,7 +162,9 @@ export default class ContourPass {
   }
 
   public setOutlinePaletteTexture(texture: DataTexture) {
+    console.log("Setting outline palette texture", texture.image.width, texture.image.height, texture);
     this.pass.material.uniforms.outlinePalette.value = texture;
+    this.pass.material.needsUpdate = true;
   }
 
   /**

--- a/src/ContourPass.ts
+++ b/src/ContourPass.ts
@@ -89,8 +89,11 @@ export default class ContourPass {
     this.pass.material.uniforms.outlineThickness.value = Math.floor(thickness);
   }
 
-  public setInnerOutlineThickness(thickness: number): void {
-    this.pass.material.uniforms.innerOutlineThickness.value = Math.floor(thickness);
+  /**
+   * Optional inner outline shown when using outline palettes for better contrast.
+   */
+  public setInnerOutlineThickness(thicknessPx: number): void {
+    this.pass.material.uniforms.innerOutlineThickness.value = Math.floor(thicknessPx);
   }
 
   private syncGlobalIdLookup(): void {
@@ -135,10 +138,21 @@ export default class ContourPass {
    * @param id The ID to highlight. If a global ID lookup has been set
    * (`setGlobalIdLookup`), this should be a global ID.
    */
-  public setHighlightedId(id: number) {
+  public setSelectedId(id: number) {
     this.pass.material.uniforms.selectedId.value = id;
   }
 
+  /**
+   * Sets the lookup table that maps from an ID to whether the ID is
+   * selected or not.
+   *
+   * For some ID `i`, if `selectedIds[i] > 0`, the ID is selected. When
+   * `useOutlinePalette` is true, the value of `selectedIds[i]` is used
+   * as the index of the outline color in the outline palette.
+   *
+   * By default, the ID is a local (pixel) ID. If a global ID
+   * lookup has been set (`setGlobalIdLookup`), the ID is parsed as a global ID.
+   */
   public setSelectedIdLut(selectedIds: Uint8Array) {
     if (this.selectedIdsTexture) {
       this.selectedIdsTexture.dispose();
@@ -156,12 +170,18 @@ export default class ContourPass {
     this.pass.material.uniforms.selectedIds.value = this.selectedIdsTexture;
   }
 
+  /**
+   * Whether to use the outline palette texture for coloring outlines.
+   * Otherwise, a solid outline color is used.
+   */
   public setUseOutlinePalette(usePalette: boolean) {
     this.pass.material.uniforms.useOutlinePalette.value = usePalette;
   }
 
+  /**
+   * Sets a texture containing the outline palette colors.
+   */
   public setOutlinePaletteTexture(texture: DataTexture) {
-    console.log("Setting outline palette texture", texture.image.width, texture.image.height, texture);
     this.pass.material.uniforms.outlinePalette.value = texture;
     this.pass.material.needsUpdate = true;
   }

--- a/src/ContourPass.ts
+++ b/src/ContourPass.ts
@@ -3,10 +3,12 @@ import {
   DataTexture,
   FloatType,
   IUniform,
+  RedFormat,
   RedIntegerFormat,
   RGBAFormat,
   Texture,
   Uniform,
+  UnsignedByteType,
   UnsignedIntType,
   WebGLRenderer,
   WebGLRenderTarget,
@@ -16,16 +18,26 @@ import { clamp } from "three/src/math/MathUtils.js";
 import RenderToBuffer, { RenderPassType } from "./RenderToBuffer.js";
 import contourFragShader from "./constants/shaders/contour.frag";
 import { ColorizeFeature } from "./types.js";
+import { getSquarestTextureDimensions } from "./utils/texture_utils.js";
 
 type ContourUniforms = {
+  // Base image (pick buffer)
   pickBuffer: IUniform<Texture>;
-  highlightedId: IUniform<number>;
-  outlineThickness: IUniform<number>;
-  outlineColor: IUniform<Color>;
-  outlineAlpha: IUniform<number>;
+  // ID information
+  selectedId: IUniform<number>;
+  selectedIds: IUniform<Texture>;
   useGlobalIdLookup: IUniform<boolean>;
   localIdToGlobalId: IUniform<Texture>;
   localIdOffset: IUniform<number>;
+  // Outline style
+  outlineThickness: IUniform<number>;
+  innerOutlineThickness: IUniform<number>;
+  backgroundColor: IUniform<Color>;
+  outlineColor: IUniform<Color>;
+  outlinePalette: IUniform<Texture>;
+  useOutlinePalette: IUniform<boolean>;
+  outlineAlpha: IUniform<number>;
+
   devicePixelRatio: IUniform<number>;
 };
 
@@ -33,12 +45,22 @@ const makeDefaultUniforms = (): ContourUniforms => {
   const pickBufferTex = new DataTexture(new Float32Array([1, 0, 0, 0]), 1, 1, RGBAFormat, FloatType);
   const localIdToGlobalId = new DataTexture(new Uint32Array([0]), 1, 1, RedIntegerFormat, UnsignedIntType);
   localIdToGlobalId.needsUpdate = true;
+  const outlinePaletteTex = new DataTexture(new Float32Array([1, 0, 0, 0]), 1, 1, RGBAFormat, FloatType);
+  outlinePaletteTex.needsUpdate = true;
+  const selectedIds = new DataTexture(new Uint8Array([0]), 1, 1, RedIntegerFormat, UnsignedByteType);
+  selectedIds.internalFormat = "R8UI";
+  selectedIds.needsUpdate = true;
   return {
     pickBuffer: new Uniform(pickBufferTex),
-    highlightedId: new Uniform(94),
+    selectedId: new Uniform(-1),
+    selectedIds: new Uniform(selectedIds),
     outlineThickness: new Uniform(2.0),
+    innerOutlineThickness: new Uniform(2.0),
+    useOutlinePalette: new Uniform(false),
+    backgroundColor: new Uniform(new Color(0, 0, 0)),
     outlineColor: new Uniform(new Color(1, 0, 1)),
     outlineAlpha: new Uniform(1.0),
+    outlinePalette: new Uniform(outlinePaletteTex),
     useGlobalIdLookup: new Uniform(false),
     localIdToGlobalId: new Uniform(localIdToGlobalId),
     localIdOffset: new Uniform(0),
@@ -50,6 +72,8 @@ export default class ContourPass {
   private pass: RenderToBuffer;
   private frameToGlobalIdLookup: ColorizeFeature["frameToGlobalIdLookup"] | null;
   private frame: number;
+
+  private selectedIdsTexture: DataTexture | null = null;
 
   constructor() {
     this.pass = new RenderToBuffer(contourFragShader, makeDefaultUniforms(), RenderPassType.TRANSPARENT);
@@ -66,6 +90,10 @@ export default class ContourPass {
     this.pass.material.uniforms.outlineThickness.value = Math.floor(thickness);
   }
 
+  public setInnerOutlineThickness(thickness: number): void {
+    this.pass.material.uniforms.innerOutlineThickness.value = Math.floor(thickness);
+  }
+
   private syncGlobalIdLookup(): void {
     const uniforms = this.pass.material.uniforms as ContourUniforms;
     const globalIdLookupInfo = this.frameToGlobalIdLookup?.get(this.frame);
@@ -80,7 +108,7 @@ export default class ContourPass {
 
   /**
    * Sets a frame-dependent lookup for global IDs. Set to a non-null value if
-   * the `highlightedId` represents a global ID instead of a local (pixel) ID.
+   * the `selectedId` represents a global ID instead of a local (pixel) ID.
    * @param frameToGlobalIdLookup A map from a frame number to a lookup object,
    * containing a texture and an offset value; see `ColorizeFeature` for more
    * details. If `null`, the pass will not use a global ID lookup.
@@ -109,7 +137,34 @@ export default class ContourPass {
    * (`setGlobalIdLookup`), this should be a global ID.
    */
   public setHighlightedId(id: number) {
-    this.pass.material.uniforms.highlightedId.value = id;
+    this.pass.material.uniforms.selectedId.value = id;
+  }
+
+  public setSelectedIdLut(selectedIds: Uint8Array) {
+    if (this.selectedIdsTexture) {
+      this.selectedIdsTexture.dispose();
+    }
+    const [width, height] = getSquarestTextureDimensions(selectedIds.length);
+    let paddedSelectedIds = selectedIds;
+    if (selectedIds.length < width * height) {
+      // Pad the array with zeros to fit the texture size
+      paddedSelectedIds = new Uint8Array(width * height);
+      paddedSelectedIds.set(selectedIds);
+    }
+    console.log("New selected IDs texture size:", paddedSelectedIds.length, width, height);
+
+    this.selectedIdsTexture = new DataTexture(paddedSelectedIds, width, height, RedIntegerFormat, UnsignedByteType);
+    this.selectedIdsTexture.internalFormat = "R8UI";
+    this.selectedIdsTexture.needsUpdate = true;
+    this.pass.material.uniforms.selectedIds.value = this.selectedIdsTexture;
+  }
+
+  public setUseOutlinePalette(usePalette: boolean) {
+    this.pass.material.uniforms.useOutlinePalette.value = usePalette;
+  }
+
+  public setOutlinePaletteTexture(texture: DataTexture) {
+    this.pass.material.uniforms.outlinePalette.value = texture;
   }
 
   /**

--- a/src/ContourPass.ts
+++ b/src/ContourPass.ts
@@ -25,7 +25,7 @@ type ContourUniforms = {
   // Outline style
   outlineThickness: IUniform<number>;
   innerOutlineThickness: IUniform<number>;
-  backgroundColor: IUniform<Color>;
+  innerOutlineColor: IUniform<Color>;
   outlineColor: IUniform<Color>;
   outlinePalette: IUniform<Texture>;
   useOutlinePalette: IUniform<boolean>;
@@ -41,11 +41,15 @@ type ContourUniforms = {
 };
 
 const makeDefaultUniforms = (): ContourUniforms => {
+  // RGBA float texture for pick buffer
   const pickBufferTex = new DataTexture(new Float32Array([0, 0, 0, 0]), 1, 1, RGBAFormat, FloatType);
+  // R32UI texture for local ID to global ID lookup
   const localIdToGlobalId = new DataTexture(new Uint32Array([0]), 1, 1, RedIntegerFormat, UnsignedIntType);
   localIdToGlobalId.needsUpdate = true;
+  // RGBA float texture for outline palette
   const outlinePaletteTex = new DataTexture(new Float32Array([1, 1, 1, 0]), 1, 1, RGBAFormat, FloatType);
   outlinePaletteTex.needsUpdate = true;
+  // R8UI texture for selected IDs
   const selectedIds = new DataTexture(new Uint8Array([0]), 1, 1, RedIntegerFormat, UnsignedByteType);
   selectedIds.internalFormat = "R8UI";
   selectedIds.needsUpdate = true;
@@ -56,7 +60,7 @@ const makeDefaultUniforms = (): ContourUniforms => {
     outlineThickness: new Uniform(2.0),
     innerOutlineThickness: new Uniform(2.0),
     useOutlinePalette: new Uniform(false),
-    backgroundColor: new Uniform(new Color(1, 1, 1)),
+    innerOutlineColor: new Uniform(new Color(1, 1, 1)),
     outlineColor: new Uniform(new Color(1, 0, 1)),
     outlineAlpha: new Uniform(1.0),
     outlinePalette: new Uniform(outlinePaletteTex),
@@ -87,6 +91,10 @@ export default class ContourPass {
 
   public setOutlineThickness(thickness: number): void {
     this.pass.material.uniforms.outlineThickness.value = Math.floor(thickness);
+  }
+
+  public setInnerOutlineColor(color: Color): void {
+    this.pass.material.uniforms.innerOutlineColor.value = color;
   }
 
   /**

--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -131,20 +131,24 @@ export default class FusedChannelData {
   }
 
   private setupFuseColorizeMaterial(fragShaderSrc: string) {
+    // Float red texture R32F
     const initialFeatureData = new DataTexture(new Float32Array([0]), 1, 1, RedFormat, FloatType);
     initialFeatureData.needsUpdate = true;
-
-    const initialOutlierData = new DataTexture(new Uint8Array([0]), 1, 1, RedFormat, UnsignedByteType);
+    // Integer red texture (R8UI)
+    const initialOutlierData = new DataTexture(new Uint8Array([0]), 1, 1, RedIntegerFormat, UnsignedByteType);
     initialOutlierData.needsUpdate = true;
-    const initialInRangeIds = new DataTexture(new Uint32Array([0]), 1, 1, RedFormat, UnsignedByteType);
+    const initialInRangeIds = new DataTexture(new Uint32Array([0]), 1, 1, RedIntegerFormat, UnsignedByteType);
     initialInRangeIds.needsUpdate = true;
-
-    const initialSegIdToGlobalId = new DataTexture(new Uint32Array([0]), 1, 1, RedFormat, UnsignedIntType);
+    // Integer red texture (R32UI)
+    const initialSegIdToGlobalId = new DataTexture(new Uint32Array([0]), 1, 1, RedIntegerFormat, UnsignedIntType);
     initialSegIdToGlobalId.needsUpdate = true;
-    const initialColorRamp = new DataTexture(new Uint8Array([0, 0, 0, 255]), 1, 1, RGBAFormat, FloatType);
+    // Float RGBA color ramp texture
+    const initialColorRamp = new DataTexture(new Uint8Array([0, 0, 0, 1]), 1, 1, RGBAFormat, FloatType);
     initialColorRamp.needsUpdate = true;
-    const initialSrcTexture = new DataTexture(new Uint8Array([0, 0, 0, 255]), 1, 1, RGBAFormat, FloatType);
+    // 8-bit RGBA source texture
+    const initialSrcTexture = new DataTexture(new Uint8Array([0, 0, 0, 255]), 1, 1, RGBAFormat, UnsignedByteType);
     initialSrcTexture.needsUpdate = true;
+
     return new ShaderMaterial({
       uniforms: {
         highlightedId: { value: -1 },

--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -19,6 +19,8 @@ import {
   Texture,
   LinearFilter,
   Vector2,
+  UnsignedIntType,
+  RedIntegerFormat,
 } from "three";
 
 import Channel from "./Channel.js";
@@ -151,7 +153,7 @@ export default class FusedChannelData {
         outlierDrawMode: { value: 0 },
         outOfRangeDrawMode: { value: 0 },
         hideOutOfRange: { value: false },
-        segIdToGlobalId: { value: new DataTexture() },
+        segIdToGlobalId: { value: new DataTexture(new Uint32Array([0]), 1, 1, RedIntegerFormat, UnsignedIntType) },
         segIdOffset: { value: 0 },
       },
       fragmentShader: fragShaderSrc,
@@ -260,7 +262,9 @@ export default class FusedChannelData {
             console.warn(
               `FusedChannelData.gpuFuse: No global ID lookup info for frame ${frame} in channel ${chIndex}. A default lookup will be used, which may cause visual artifacts.`
             );
-            globalIdLookupInfo = { texture: new DataTexture(Uint32Array[0]), minSegId: 1 };
+            const fallbackTexture = new DataTexture(new Uint32Array([0]), 1, 1, RedIntegerFormat, UnsignedIntType);
+            fallbackTexture.needsUpdate = true;
+            globalIdLookupInfo = { texture: fallbackTexture, minSegId: 1 };
           }
           mat.uniforms.segIdToGlobalId.value = globalIdLookupInfo.texture;
           mat.uniforms.segIdOffset.value = globalIdLookupInfo.minSegId;

--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -21,6 +21,7 @@ import {
   Vector2,
   UnsignedIntType,
   RedIntegerFormat,
+  FloatType,
 } from "three";
 
 import Channel from "./Channel.js";
@@ -130,21 +131,35 @@ export default class FusedChannelData {
   }
 
   private setupFuseColorizeMaterial(fragShaderSrc: string) {
+    const initialFeatureData = new DataTexture(new Float32Array([0]), 1, 1, RedFormat, FloatType);
+    initialFeatureData.needsUpdate = true;
+
+    const initialOutlierData = new DataTexture(new Uint8Array([0]), 1, 1, RedFormat, UnsignedByteType);
+    initialOutlierData.needsUpdate = true;
+    const initialInRangeIds = new DataTexture(new Uint32Array([0]), 1, 1, RedFormat, UnsignedByteType);
+    initialInRangeIds.needsUpdate = true;
+
+    const initialSegIdToGlobalId = new DataTexture(new Uint32Array([0]), 1, 1, RedFormat, UnsignedIntType);
+    initialSegIdToGlobalId.needsUpdate = true;
+    const initialColorRamp = new DataTexture(new Uint8Array([0, 0, 0, 255]), 1, 1, RGBAFormat, FloatType);
+    initialColorRamp.needsUpdate = true;
+    const initialSrcTexture = new DataTexture(new Uint8Array([0, 0, 0, 255]), 1, 1, RGBAFormat, FloatType);
+    initialSrcTexture.needsUpdate = true;
     return new ShaderMaterial({
       uniforms: {
         highlightedId: { value: -1 },
         featureData: {
-          value: null,
+          value: initialFeatureData,
         },
-        outlierData: { value: null },
-        inRangeIds: { value: null },
+        outlierData: { value: initialOutlierData },
+        inRangeIds: { value: initialInRangeIds },
         srcTexture: {
-          value: null,
+          value: initialSrcTexture,
         },
         featureColorRampMin: { value: 0 },
         featureColorRampMax: { value: 1 },
         colorRamp: {
-          value: null,
+          value: initialColorRamp,
         },
         useRepeatingCategoricalColors: { value: false },
         outlineColor: { value: new Color(0xffffff) },
@@ -153,7 +168,7 @@ export default class FusedChannelData {
         outlierDrawMode: { value: 0 },
         outOfRangeDrawMode: { value: 0 },
         hideOutOfRange: { value: false },
-        segIdToGlobalId: { value: new DataTexture(new Uint32Array([0]), 1, 1, RedIntegerFormat, UnsignedIntType) },
+        segIdToGlobalId: { value: initialSegIdToGlobalId },
         segIdOffset: { value: 0 },
       },
       fragmentShader: fragShaderSrc,
@@ -262,9 +277,9 @@ export default class FusedChannelData {
             console.warn(
               `FusedChannelData.gpuFuse: No global ID lookup info for frame ${frame} in channel ${chIndex}. A default lookup will be used, which may cause visual artifacts.`
             );
-            const fallbackTexture = new DataTexture(new Uint32Array([0]), 1, 1, RedIntegerFormat, UnsignedIntType);
-            fallbackTexture.needsUpdate = true;
-            globalIdLookupInfo = { texture: fallbackTexture, minSegId: 1 };
+            const texture = new DataTexture(new Uint32Array([0]), 1, 1, RedIntegerFormat, UnsignedIntType);
+            texture.needsUpdate = true;
+            globalIdLookupInfo = { texture, minSegId: 1 };
           }
           mat.uniforms.segIdToGlobalId.value = globalIdLookupInfo.texture;
           mat.uniforms.segIdOffset.value = globalIdLookupInfo.minSegId;

--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -238,7 +238,6 @@ export default class FusedChannelData {
         // must clone the material to keep a unique set of uniforms
         const mat = this.getShader(channels[chIndex].dtype, isColorize).clone();
         mat.uniforms.srcTexture.value = channels[chIndex].dataTexture;
-        mat.uniforms.highlightedId.value = combination[i].selectedID == undefined ? -1 : combination[i].selectedID;
         const feature = combination[i].feature;
         if (isColorize && feature) {
           mat.uniforms.featureData.value = feature.idsToFeatureValue;

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -323,6 +323,8 @@ export class View3d {
    * @param featureInfo A collection of all parameters necessary to colorize the channel. Pass null to turn off colorization.
    */
   setChannelColorizeFeature(volume: Volume, channelIndex: number, featureInfo: ColorizeFeature | null): void {
+    // TODO: Allow `featureInfo` to be `Partial<ColorizeFeature>` and only
+    // update the provided fields.
     this.image?.setChannelColorizeFeature(channelIndex, featureInfo);
     this.image?.fuse();
     this.redraw();
@@ -982,8 +984,8 @@ export class View3d {
    * (`outlinePalette`) when set via `setChannelColorizeFeature()`.
    */
   setSelectedIDs(idLut: Uint8Array): void {
-    const needRedraw = this.image?.setSelectedIdsLut(idLut);
-    if (needRedraw) {
+    this.image?.setSelectedIdsLut(idLut);
+    if (this.image) {
       this.redraw();
     }
   }

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -968,7 +968,8 @@ export class View3d {
    * @param id the selected id
    */
   setSelectedID(volume: Volume, channel: number, id: number): void {
-    // Note: Channel and volume do not do anything currently... deprecate/refactor in the future?
+    // Note: Channel and volume params do not do anything currently...
+    // deprecate/refactor in the future?
     const needRedraw = this.image?.setSelectedID(channel, id);
     if (needRedraw) {
       this.image?.fuse();
@@ -980,8 +981,8 @@ export class View3d {
    * @description Sets a lookup table mapping from an ID to whether it is
    * selected. Used for outlining multiple selected IDs.
    * @param idLut A Uint8Array where, for an ID `i`, `idLut[i] > 0` if the ID is
-   * selected. `idLut[i]` is used to index into the outline palette
-   * (`outlinePalette`) when set via `setChannelColorizeFeature()`.
+   * selected. When the outline palette is enabled (see `setChannelColorizeFeature()`),
+   * the color is given by `outlinePalette[idLut[i] - 1]`.
    */
   setSelectedIDs(idLut: Uint8Array): void {
     this.image?.setSelectedIdsLut(idLut);

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -972,6 +972,13 @@ export class View3d {
     }
   }
 
+  setSelectedIDs(idLut: Uint8Array): void {
+    const needRedraw = this.image?.setSelectedIdsLut(idLut);
+    if (needRedraw) {
+      this.redraw();
+    }
+  }
+
   /**
    * Adds a Line3d object as a child of the Volume, if a volume has been added
    * to the view and the line is not already a child of it. Line positions will

--- a/src/View3d.ts
+++ b/src/View3d.ts
@@ -959,12 +959,14 @@ export class View3d {
   }
 
   /**
-   * @description Set the selected ID for a given channel.  This is used to change the appearance of the volume where that id is.
+   * @description Set the selected ID for a given channel. This is used to show
+   * an outline around pixels with the selected ID.
    * @param volume the image to set the selected ID on
    * @param channel the channel index where the selected ID is
    * @param id the selected id
    */
   setSelectedID(volume: Volume, channel: number, id: number): void {
+    // Note: Channel and volume do not do anything currently... deprecate/refactor in the future?
     const needRedraw = this.image?.setSelectedID(channel, id);
     if (needRedraw) {
       this.image?.fuse();
@@ -972,6 +974,13 @@ export class View3d {
     }
   }
 
+  /**
+   * @description Sets a lookup table mapping from an ID to whether it is
+   * selected. Used for outlining multiple selected IDs.
+   * @param idLut A Uint8Array where, for an ID `i`, `idLut[i] > 0` if the ID is
+   * selected. `idLut[i]` is used to index into the outline palette
+   * (`outlinePalette`) when set via `setChannelColorizeFeature()`.
+   */
   setSelectedIDs(idLut: Uint8Array): void {
     const needRedraw = this.image?.setSelectedIdsLut(idLut);
     if (needRedraw) {

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -507,7 +507,8 @@ export default class VolumeDrawable {
     return this.meshVolume.hasIsosurface(channel);
   }
 
-  // TODO: Deprecate?
+  // TODO: Deprecate in favor of `setSelectedIdsLut`? Currently the shader
+  // supports both selecting a single ID and selecting multiple IDs via a LUT.
   setSelectedID(_channelIndex: number, id: number): void {
     this.contourRendering.setSelectedId(id);
   }

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -729,6 +729,8 @@ export default class VolumeDrawable {
     } else {
       this.fusion[channelIndex].feature = featureInfo;
       this.contourRendering.setOutlineColor(featureInfo.outlineColor, featureInfo.outlineAlpha);
+      this.contourRendering.setInnerOutlineColor(featureInfo.innerOutlineColor);
+      this.contourRendering.setInnerOutlineThickness(featureInfo.innerOutlineThickness);
       this.contourRendering.setOutlinePaletteTexture(featureInfo.outlinePalette);
       this.contourRendering.setUseOutlinePalette(featureInfo.useOutlinePalette);
       this.contourRendering.setGlobalIdLookup(featureInfo.frameToGlobalIdLookup);

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -102,7 +102,6 @@ export default class VolumeDrawable {
         chIndex: index,
         lut: new Uint8Array(LUT_ARRAY_LENGTH),
         rgbColor: rgbColor,
-        selectedID: -1,
       };
     });
 
@@ -508,15 +507,8 @@ export default class VolumeDrawable {
     return this.meshVolume.hasIsosurface(channel);
   }
 
-  setSelectedID(channelIndex: number, id: number): boolean {
+  setSelectedID(_channelIndex: number, id: number): boolean {
     this.contourRendering.setHighlightedId(id);
-    if (this.fusion.length > 0) {
-      // TODO does it make sense to do this for a particular channel?
-      if (id !== this.fusion[channelIndex].selectedID) {
-        this.fusion[channelIndex].selectedID = id;
-        return true;
-      }
-    }
     return false;
   }
 
@@ -608,7 +600,6 @@ export default class VolumeDrawable {
         this.channelColors[newChannelIndex][1],
         this.channelColors[newChannelIndex][2],
       ],
-      selectedID: -1,
     };
 
     this.settings.diffuse[newChannelIndex] = [

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -507,8 +507,6 @@ export default class VolumeDrawable {
     return this.meshVolume.hasIsosurface(channel);
   }
 
-  // TODO: Deprecate in favor of `setSelectedIdsLut`? Currently the shader
-  // supports both selecting a single ID and selecting multiple IDs via a LUT.
   setSelectedID(_channelIndex: number, id: number): void {
     this.contourRendering.setSelectedId(id);
   }

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -728,7 +728,6 @@ export default class VolumeDrawable {
     // TODO only one channel can ever have this?
     if (!featureInfo) {
       this.fusion[channelIndex].feature = undefined;
-      this.contourRendering.setGlobalIdLookup(null);
     } else {
       this.fusion[channelIndex].feature = featureInfo;
       this.contourRendering.setOutlineColor(featureInfo.outlineColor, featureInfo.outlineAlpha);

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -508,14 +508,12 @@ export default class VolumeDrawable {
   }
 
   // TODO: Deprecate?
-  setSelectedID(_channelIndex: number, id: number): boolean {
-    this.contourRendering.setHighlightedId(id);
-    return false;
+  setSelectedID(_channelIndex: number, id: number): void {
+    this.contourRendering.setSelectedId(id);
   }
 
-  setSelectedIdsLut(selectedIds: Uint8Array): boolean {
+  setSelectedIdsLut(selectedIds: Uint8Array): void {
     this.contourRendering.setSelectedIdLut(selectedIds);
-    return true;
   }
 
   fuse(): void {

--- a/src/VolumeDrawable.ts
+++ b/src/VolumeDrawable.ts
@@ -507,9 +507,15 @@ export default class VolumeDrawable {
     return this.meshVolume.hasIsosurface(channel);
   }
 
+  // TODO: Deprecate?
   setSelectedID(_channelIndex: number, id: number): boolean {
     this.contourRendering.setHighlightedId(id);
     return false;
+  }
+
+  setSelectedIdsLut(selectedIds: Uint8Array): boolean {
+    this.contourRendering.setSelectedIdLut(selectedIds);
+    return true;
   }
 
   fuse(): void {
@@ -726,6 +732,8 @@ export default class VolumeDrawable {
     } else {
       this.fusion[channelIndex].feature = featureInfo;
       this.contourRendering.setOutlineColor(featureInfo.outlineColor, featureInfo.outlineAlpha);
+      this.contourRendering.setOutlinePaletteTexture(featureInfo.outlinePalette);
+      this.contourRendering.setUseOutlinePalette(featureInfo.useOutlinePalette);
       this.contourRendering.setGlobalIdLookup(featureInfo.frameToGlobalIdLookup);
     }
     this.volumeRendering.updateSettings(this.settings, SettingsFlags.MATERIAL);

--- a/src/constants/shaders/contour.frag
+++ b/src/constants/shaders/contour.frag
@@ -127,6 +127,7 @@ void main(void) {
       // When coloring with the track palette, apply an additional inner outline
       // using the background color for better contrast against the track
       // outline color.
+      // gl_FragColor = vec4(0, 0, 0, 0.0);
       gl_FragColor = vec4(backgroundColor.rgb, outlineAlpha);
     }
   } else {

--- a/src/constants/shaders/contour.frag
+++ b/src/constants/shaders/contour.frag
@@ -27,7 +27,6 @@ uniform sampler2D pickBuffer;
 uniform usampler2D selectedIds;
 uniform int selectedId;
 uniform int outlineThickness;
-uniform int innerOutlineThickness;
 uniform float outlineAlpha;
 /**
  * If true, uses the `outlinePalette` to outline selected tracks, and
@@ -37,8 +36,9 @@ uniform float outlineAlpha;
 uniform bool useOutlinePalette;
 uniform vec3 outlineColor;
 uniform sampler2D outlinePalette;
+uniform vec3 innerOutlineColor;
+uniform int innerOutlineThickness;
 uniform float devicePixelRatio;
-uniform vec3 backgroundColor;
 
 const uint BACKGROUND_ID = 0u;
 const int MISSING_DATA_ID = -1;
@@ -82,7 +82,7 @@ int getGlobalId(uint labelId) {
   }
   int localId = int(labelId) - int(localIdOffset);
   if (!useGlobalIdLookup) {
-    return (localId + ID_OFFSET);
+    return (localId - ID_OFFSET);
   }
   uvec4 c = getUintFromTex(localIdToGlobalId, localId);
   // Note: IDs are offset by `ID_OFFSET` (`=1`) to reserve `0` for local IDs
@@ -122,14 +122,14 @@ void main(void) {
   uint selectionIdx = getUintFromTex(selectedIds, id).r;
   if (selectionIdx > 0u || id == selectedId) {
     if (isEdge(vUv, labelId, outlineThickness)) {
-      int colorIdx = int(selectionIdx) - 1;
+      int colorIdx = max(0, int(selectionIdx) - 1);
       vec4 color = getOutlineColor(colorIdx);
       gl_FragColor = vec4(color.rgb, outlineAlpha);
-    } else if (isEdge(vUv, labelId, outlineThickness + innerOutlineThickness) && useOutlinePalette) {
+    } else if (innerOutlineThickness > 0 && isEdge(vUv, labelId, outlineThickness + innerOutlineThickness)) {
       // When coloring with the track palette, apply an additional inner outline
       // using the background color for better contrast against the track
       // outline color.
-      gl_FragColor = vec4(backgroundColor.rgb, outlineAlpha);
+      gl_FragColor = vec4(innerOutlineColor.rgb, outlineAlpha);
     }
   } else {
     gl_FragColor = vec4(0, 0, 0, 0.0);

--- a/src/constants/shaders/contour.frag
+++ b/src/constants/shaders/contour.frag
@@ -60,7 +60,7 @@ vec4 getOutlineColor(int colorIdx) {
 }
 
 /**
- * Gets the label ID of the pixel at the given scaled UV
+ * Gets the label ID (aka raw pixel value) of the pixel at the given scaled UV
  * coordinates.
  */
 uint getLabelId(ivec2 uv) {
@@ -71,12 +71,14 @@ uint getLabelId(ivec2 uv) {
  * Looks up the global ID value from its label ID. The global ID can be used to
  * get data about this object from data buffers like `featureData` and
  * `outlierData`.
- * @returns The global ID at the given coordinates, or -1 (=MISSING_DATA_ID) if
- *     the pixel is background or missing data.
+ * @returns One of the following:
+ * - `-1` (=MISSING_DATA_ID) if the pixel is missing data or is part of the
+     background.
+ * - The global ID at the given coordinates.
  */
 int getGlobalId(uint labelId) {
-  if (labelId == 0u) {
-    return int(BACKGROUND_ID);
+  if (labelId == BACKGROUND_ID) {
+    return MISSING_DATA_ID;
   }
   int localId = int(labelId) - int(localIdOffset);
   if (!useGlobalIdLookup) {

--- a/src/constants/shaders/contour.frag
+++ b/src/constants/shaders/contour.frag
@@ -16,14 +16,32 @@ uniform bool useGlobalIdLookup;
 /* Pick buffer. Used to determine IDs. */
 uniform sampler2D pickBuffer;
 
-uniform int highlightedId;
+/** 
+ * A mapping of IDs that are selected in the current track(s). If an object's
+ * index is `i`, `selectedIds[i] >= 1` if the object is selected.
+ *
+ * For selected objects, `selectedIds[i] - 1` is the index into the
+ * `selectedTracksPalette` for the outline color that should be used when
+ * `useTracksPalette` is true.
+ */
+uniform usampler2D selectedIds;
+uniform int selectedId;
 uniform int outlineThickness;
+uniform int innerOutlineThickness;
 uniform float outlineAlpha;
+/**
+ * If true, uses the `outlinePalette` to outline selected tracks, and
+ * shows an additional inner outline. When false, uses `outlineColor` for
+ * outlines.
+ */
+uniform bool useOutlinePalette;
 uniform vec3 outlineColor;
+uniform sampler2D outlinePalette;
 uniform float devicePixelRatio;
+uniform vec3 backgroundColor;
 
 const uint BACKGROUND_ID = 0u;
-const uint MISSING_DATA_ID = 0xFFFFFFFFu;
+const int MISSING_DATA_ID = -1;
 const int ID_OFFSET = 1;
 
 uvec4 getUintFromTex(usampler2D tex, int index) {
@@ -32,14 +50,37 @@ uvec4 getUintFromTex(usampler2D tex, int index) {
   return uvec4(texelFetch(tex, featurePos, 0));
 }
 
-uint getId(ivec2 uv) {
-  float rawId = texelFetch(pickBuffer, uv, 0).g;
-  if (rawId == 0.0) {
-    return BACKGROUND_ID;
+vec4 getOutlineColor(int colorIdx) {
+  if (!useOutlinePalette) {
+    return vec4(outlineColor, 1);
   }
-  int localId = int(rawId) - int(localIdOffset);
+  float width = float(textureSize(outlinePalette, 0).x);
+  float adjustedIdx = (0.5 + float(colorIdx)) / width;
+  return texture(outlinePalette, vec2(adjustedIdx, 0.5));
+}
+
+/**
+ * Gets the label ID of the pixel at the given scaled UV
+ * coordinates.
+ */
+uint getLabelId(ivec2 uv) {
+  return uint(texelFetch(pickBuffer, uv, 0).g);
+}
+
+/**
+ * Looks up the global ID value from its label ID. The global ID can be used to
+ * get data about this object from data buffers like `featureData` and
+ * `outlierData`.
+ * @returns The global ID at the given coordinates, or -1 (=MISSING_DATA_ID) if
+ *     the pixel is background or missing data.
+ */
+int getGlobalId(uint labelId) {
+  if (labelId == 0u) {
+    return int(BACKGROUND_ID);
+  }
+  int localId = int(labelId) - int(localIdOffset);
   if (!useGlobalIdLookup) {
-    return uint(localId + ID_OFFSET);
+    return (localId + ID_OFFSET);
   }
   uvec4 c = getUintFromTex(localIdToGlobalId, localId);
   // Note: IDs are offset by `ID_OFFSET` (`=1`) to reserve `0` for local IDs
@@ -49,30 +90,45 @@ uint getId(ivec2 uv) {
   if (globalId == 0u) {
     return MISSING_DATA_ID;
   }
-  return globalId;
+  return int(globalId) - ID_OFFSET;
 }
 
-bool isEdge(ivec2 uv, int id, int thickness) {
+bool isEdge(ivec2 uv, uint labelId, int thickness) {
   float wStep = 1.0;
   float hStep = 1.0;
   float thicknessFloat = float(thickness);
   // sample around the pixel to see if we are on an edge
-  int R = int(getId(uv + ivec2(thicknessFloat * wStep, 0))) - ID_OFFSET;
-  int L = int(getId(uv + ivec2(-thicknessFloat * wStep, 0))) - ID_OFFSET;
-  int T = int(getId(uv + ivec2(0, thicknessFloat * hStep))) - ID_OFFSET;
-  int B = int(getId(uv + ivec2(0, -thicknessFloat * hStep))) - ID_OFFSET;
+  uint R = (getLabelId(uv + ivec2(thicknessFloat * wStep, 0)));
+  uint L = (getLabelId(uv + ivec2(-thicknessFloat * wStep, 0)));
+  uint T = (getLabelId(uv + ivec2(0, thicknessFloat * hStep)));
+  uint B = (getLabelId(uv + ivec2(0, -thicknessFloat * hStep)));
   // if any neighbors are not id then this is an edge
-  return id != -1 && (R != id || L != id || T != id || B != id);
+  return labelId != BACKGROUND_ID && (R != labelId || L != labelId || T != labelId || B != labelId);
 }
 
 void main(void) {
   ivec2 vUv = ivec2(int(gl_FragCoord.x / devicePixelRatio), int(gl_FragCoord.y / devicePixelRatio));
 
-  uint rawId = getId(vUv);
-  int id = int(rawId) - ID_OFFSET;
+  uint labelId = getLabelId(vUv);
+  int id = getGlobalId(labelId);
 
-  if (id == highlightedId && isEdge(vUv, id, outlineThickness)) {
-    gl_FragColor = vec4(outlineColor, outlineAlpha);
+  if (id == MISSING_DATA_ID || labelId == BACKGROUND_ID) {
+    gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
+    return;
+  }
+
+  uint selectionIdx = getUintFromTex(selectedIds, id).r;
+  if (selectionIdx > 0u || id == selectedId) {
+    if (isEdge(vUv, labelId, outlineThickness)) {
+      int colorIdx = int(selectionIdx) - 1;
+      vec4 color = getOutlineColor(colorIdx);
+      gl_FragColor = vec4(color.rgb, outlineAlpha);
+    } else if (isEdge(vUv, labelId, outlineThickness + innerOutlineThickness) && useOutlinePalette) {
+      // When coloring with the track palette, apply an additional inner outline
+      // using the background color for better contrast against the track
+      // outline color.
+      gl_FragColor = vec4(backgroundColor.rgb, outlineAlpha);
+    }
   } else {
     gl_FragColor = vec4(0, 0, 0, 0.0);
   }

--- a/src/constants/shaders/contour.frag
+++ b/src/constants/shaders/contour.frag
@@ -21,8 +21,8 @@ uniform sampler2D pickBuffer;
  * index is `i`, `selectedIds[i] >= 1` if the object is selected.
  *
  * For selected objects, `selectedIds[i] - 1` is the index into the
- * `selectedTracksPalette` for the outline color that should be used when
- * `useTracksPalette` is true.
+ * `outlinePalette` for the outline color that should be used when
+ * `useOutlinePalette` is true.
  */
 uniform usampler2D selectedIds;
 uniform int selectedId;

--- a/src/constants/shaders/contour.frag
+++ b/src/constants/shaders/contour.frag
@@ -127,7 +127,6 @@ void main(void) {
       // When coloring with the track palette, apply an additional inner outline
       // using the background color for better contrast against the track
       // outline color.
-      // gl_FragColor = vec4(0, 0, 0, 0.0);
       gl_FragColor = vec4(backgroundColor.rgb, outlineAlpha);
     }
   } else {

--- a/src/constants/shaders/contour.frag
+++ b/src/constants/shaders/contour.frag
@@ -17,23 +17,27 @@ uniform bool useGlobalIdLookup;
 uniform sampler2D pickBuffer;
 
 /** 
- * A mapping of IDs that are selected in the current track(s). If an object's
- * index is `i`, `selectedIds[i] >= 1` if the object is selected.
+ * A mapping of IDs that are selected in the current track(s). For some object
+ * with ID given by `i`, `selectedIds[i] >= 1` if the object is selected.
  *
  * For selected objects, `selectedIds[i] - 1` is the index into the
  * `outlinePalette` for the outline color that should be used when
  * `useOutlinePalette` is true.
  */
 uniform usampler2D selectedIds;
+/** 
+ * Legacy method of highlighting a single ID. Uses the `outlineColor` for the outline 
+ * or `outlinePalette[0]` when `useOutlinePalette` is true.
+*/
 uniform int selectedId;
-uniform int outlineThickness;
-uniform float outlineAlpha;
 /**
- * If true, uses the `outlinePalette` to outline selected tracks, and
- * shows an additional inner outline. When false, uses `outlineColor` for
- * outlines.
+ * If true, uses the `outlinePalette` to outline selected tracks based on the
+ * selected ID, and shows an additional inner outline. When false, uses
+ * `outlineColor` for outlines.
  */
 uniform bool useOutlinePalette;
+uniform int outlineThickness;
+uniform float outlineAlpha;
 uniform vec3 outlineColor;
 uniform sampler2D outlinePalette;
 uniform vec3 innerOutlineColor;
@@ -82,7 +86,7 @@ int getGlobalId(uint labelId) {
   }
   int localId = int(labelId) - int(localIdOffset);
   if (!useGlobalIdLookup) {
-    return (localId - ID_OFFSET);
+    return localId - ID_OFFSET;
   }
   uvec4 c = getUintFromTex(localIdToGlobalId, localId);
   // Note: IDs are offset by `ID_OFFSET` (`=1`) to reserve `0` for local IDs
@@ -112,23 +116,22 @@ void main(void) {
   ivec2 vUv = ivec2(int(gl_FragCoord.x / devicePixelRatio), int(gl_FragCoord.y / devicePixelRatio));
 
   uint labelId = getLabelId(vUv);
-  int id = getGlobalId(labelId);
+  int globalId = getGlobalId(labelId);
 
-  if (id == MISSING_DATA_ID || labelId == BACKGROUND_ID) {
+  if (globalId == MISSING_DATA_ID || labelId == BACKGROUND_ID) {
     gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
     return;
   }
 
-  uint selectionIdx = getUintFromTex(selectedIds, id).r;
-  if (selectionIdx > 0u || id == selectedId) {
+  uint selectionIdx = getUintFromTex(selectedIds, globalId).r;
+  if (selectionIdx > 0u || globalId == selectedId) {
     if (isEdge(vUv, labelId, outlineThickness)) {
+      // If matched on `selectedId` only, selectionIdx will be 0. Use color index 0.
       int colorIdx = max(0, int(selectionIdx) - 1);
       vec4 color = getOutlineColor(colorIdx);
       gl_FragColor = vec4(color.rgb, outlineAlpha);
     } else if (innerOutlineThickness > 0 && isEdge(vUv, labelId, outlineThickness + innerOutlineThickness)) {
-      // When coloring with the track palette, apply an additional inner outline
-      // using the background color for better contrast against the track
-      // outline color.
+      // Optionally apply an additional inner outline for increased contrast.
       gl_FragColor = vec4(innerOutlineColor.rgb, outlineAlpha);
     }
   } else {

--- a/src/constants/shaders/fuseUI.frag
+++ b/src/constants/shaders/fuseUI.frag
@@ -7,7 +7,6 @@ precision highp sampler3D;
 uniform sampler2D lutSampler;
 
 uniform vec2 lutMinMax;
-uniform uint highlightedId;
 
 // src texture is the raw volume intensity data
 uniform usampler2D srcTexture;

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,8 @@ export interface ColorizeFeature {
   outlineColor: Color;
   outlinePalette: DataTexture;
   useOutlinePalette: boolean;
+  innerOutlineColor: Color;
+  innerOutlineThickness: number;
   outlineAlpha: number;
   outlierColor: Color;
   outOfRangeColor: Color;

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,8 +124,6 @@ export interface FuseChannel {
   lut: Uint8Array;
   // zero is a sentinel value to disable from fusion
   rgbColor: [number, number, number] | number;
-  // the selected id will have its intensity auto-mapped to a pick color
-  selectedID: number;
   // if we are colorizing by feature, all the following inputs are needed
   feature?: ColorizeFeature;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,6 +92,8 @@ export interface ColorizeFeature {
   featureMin: number;
   featureMax: number;
   outlineColor: Color;
+  outlinePalette: DataTexture;
+  useOutlinePalette: boolean;
   outlineAlpha: number;
   outlierColor: Color;
   outOfRangeColor: Color;

--- a/src/utils/texture_utils.ts
+++ b/src/utils/texture_utils.ts
@@ -1,6 +1,7 @@
 export function getSquarestTextureDimensions(size: number): [number, number] {
-  const width = Math.ceil(Math.sqrt(size));
-  const height = Math.ceil(size / width);
+  const safeSize = Math.max(1, size);
+  const width = Math.ceil(Math.sqrt(safeSize));
+  const height = Math.ceil(safeSize / width);
 
   return [width, height];
 }

--- a/src/utils/texture_utils.ts
+++ b/src/utils/texture_utils.ts
@@ -1,4 +1,5 @@
 export function getSquarestTextureDimensions(size: number): [number, number] {
+  // Set a minimum size of 1 to prevent zero-dimension textures
   const safeSize = Math.max(1, size);
   const width = Math.ceil(Math.sqrt(safeSize));
   const height = Math.ceil(safeSize / width);

--- a/src/utils/texture_utils.ts
+++ b/src/utils/texture_utils.ts
@@ -1,0 +1,6 @@
+export function getSquarestTextureDimensions(size: number): [number, number] {
+  const width = Math.ceil(Math.sqrt(size));
+  const height = Math.ceil(size / width);
+
+  return [width, height];
+}


### PR DESCRIPTION
# Problem

Supporting changes for https://github.com/allen-cell-animated/timelapse-colorizer/issues/310 in TFE's 3D mode! This change allows multiple onscreen segmentations to be selected at once, and also allows different colors to be applied. 

*Estimated review size: medium, 25-30 minutes*

# Solution

- Updated shader ID handling for clarity, added support for multiple outlined objects + outline colors.
- Added `outlinePalette` and `useOutlinePalette` texture + flag to the ColorizeFeature type.
- Added setter for selected ID LUT.

Misc:
- Removes unused setters/types for old method of highlighting IDs, which involved highlighting them in the fuse step.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots (optional):

**Video talk-through (🔊):**

https://github.com/user-attachments/assets/93c6bc00-74f5-4df4-983c-b33864b4a7be


<img width="580" height="531" alt="image" src="https://github.com/user-attachments/assets/e4e04e89-9335-4a74-a516-3dfea23692f7" />
