### PR TITLE
Bugfix: frame dropping

### DIFF
--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -36,7 +36,7 @@ import type { FuseChannel, NumberType } from "./types.js";
  * Immutable snapshot of the Channel fields needed by gpuFuse, captured at fuse() time.
  * Snapshot is required to avoid race conditions because Channels are mutable.
  */
-type Fusable = FuseChannel & {
+type FusableChannelState = FuseChannel & {
   snapshot: {
     dtype: NumberType;
     dataTexture: DataTexture;
@@ -55,7 +55,7 @@ export default class FusedChannelData {
 
   public maskTexture: DataTexture;
 
-  private fuseRequested: Fusable[] | null;
+  private fuseRequested: FusableChannelState[] | null;
 
   private fuseGeometry: PlaneGeometry;
   private fuseMaterialF: ShaderMaterial;
@@ -225,7 +225,7 @@ export default class FusedChannelData {
      * mutating the live Channel objects between fuse() and the next
      * requestAnimationFrame
      */
-    const readyToFuse: Fusable[] = [];
+    const readyToFuse: FusableChannelState[] = [];
     for (let i = 0; i < combination.length; ++i) {
       const c = combination[i];
       const idx = c.chIndex;

--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -207,9 +207,10 @@ export default class FusedChannelData {
   }
 
   fuse(combination: FuseChannel[], channels: Channel[]): void {
-    // we can fuse if we have any loaded channels that are showing.
-    // actually, we can fuse if no channels are showing (but they are loaded), too.
-    let canFuse = false;
+    // Snapshot which channels are loaded and enabled right now,
+    // so gpuFuse() renders from this decision rather than re-reading
+    // mutable `channel.loaded` (which may be cleared by a concurrent load).
+    const readyToFuse: FuseChannel[] = [];
     for (let i = 0; i < combination.length; ++i) {
       const c = combination[i];
       const idx = c.chIndex;
@@ -217,17 +218,18 @@ export default class FusedChannelData {
         // set the lut in this fuse combination.
         // can optimize by calling combineLuts more lazily
         c.lut = channels[idx].combineLuts(c.rgbColor, c.lut);
-        canFuse = true;
-        //break;
+        if (c.rgbColor) {
+          readyToFuse.push(c);
+        }
       }
     }
-    if (!canFuse) {
+    if (readyToFuse.length === 0) {
       this.channelsDataToFuse = [];
-      this.fuseRequested = [];
+      this.fuseRequested = null;
       return;
     }
 
-    this.fuseRequested = combination;
+    this.fuseRequested = readyToFuse;
     this.channelsDataToFuse = channels;
   }
 
@@ -249,51 +251,46 @@ export default class FusedChannelData {
     });
     this.fuseScene.clear();
     for (let i = 0; i < combination.length; ++i) {
-      if (combination[i].rgbColor) {
-        const chIndex = combination[i].chIndex;
-        if (!channels[chIndex].loaded) {
-          continue;
-        }
-        const isColorize = combination[i].feature !== undefined;
-        // add a draw call per channel here.
-        // must clone the material to keep a unique set of uniforms
-        const mat = this.getShader(channels[chIndex].dtype, isColorize).clone();
-        mat.uniforms.srcTexture.value = channels[chIndex].dataTexture;
-        const feature = combination[i].feature;
-        if (isColorize && feature) {
-          mat.uniforms.featureData.value = feature.idsToFeatureValue;
-          mat.uniforms.outlierData.value = feature.outlierData;
-          mat.uniforms.inRangeIds.value = feature.inRangeIds;
-          mat.uniforms.featureColorRampMin.value = feature.featureMin;
-          mat.uniforms.featureColorRampMax.value = feature.featureMax;
-          mat.uniforms.colorRamp.value = feature.featureValueToColor;
-          mat.uniforms.useRepeatingCategoricalColors.value = feature.useRepeatingColor;
-          mat.uniforms.outlineColor.value = feature.outlineColor;
-          mat.uniforms.outlierColor.value = feature.outlierColor;
-          mat.uniforms.outOfRangeColor.value = feature.outOfRangeColor;
-          mat.uniforms.outlierDrawMode.value = feature.outlierDrawMode;
-          mat.uniforms.outOfRangeDrawMode.value = feature.outOfRangeDrawMode;
-          mat.uniforms.hideOutOfRange.value = feature.hideOutOfRange;
+      const chIndex = combination[i].chIndex;
+      const isColorize = combination[i].feature !== undefined;
+      // add a draw call per channel here.
+      // must clone the material to keep a unique set of uniforms
+      const mat = this.getShader(channels[chIndex].dtype, isColorize).clone();
+      mat.uniforms.srcTexture.value = channels[chIndex].dataTexture;
+      const feature = combination[i].feature;
+      if (isColorize && feature) {
+        mat.uniforms.featureData.value = feature.idsToFeatureValue;
+        mat.uniforms.outlierData.value = feature.outlierData;
+        mat.uniforms.inRangeIds.value = feature.inRangeIds;
+        mat.uniforms.featureColorRampMin.value = feature.featureMin;
+        mat.uniforms.featureColorRampMax.value = feature.featureMax;
+        mat.uniforms.colorRamp.value = feature.featureValueToColor;
+        mat.uniforms.useRepeatingCategoricalColors.value = feature.useRepeatingColor;
+        mat.uniforms.outlineColor.value = feature.outlineColor;
+        mat.uniforms.outlierColor.value = feature.outlierColor;
+        mat.uniforms.outOfRangeColor.value = feature.outOfRangeColor;
+        mat.uniforms.outlierDrawMode.value = feature.outlierDrawMode;
+        mat.uniforms.outOfRangeDrawMode.value = feature.outOfRangeDrawMode;
+        mat.uniforms.hideOutOfRange.value = feature.hideOutOfRange;
 
-          const frame = channels[chIndex].frame;
-          let globalIdLookupInfo = feature.frameToGlobalIdLookup.get(frame);
-          if (!globalIdLookupInfo) {
-            console.warn(
-              `FusedChannelData.gpuFuse: No global ID lookup info for frame ${frame} in channel ${chIndex}. A default lookup will be used, which may cause visual artifacts.`
-            );
-            const texture = new DataTexture(new Uint32Array([0]), 1, 1, RedIntegerFormat, UnsignedIntType);
-            texture.needsUpdate = true;
-            globalIdLookupInfo = { texture, minSegId: 1 };
-          }
-          mat.uniforms.segIdToGlobalId.value = globalIdLookupInfo.texture;
-          mat.uniforms.segIdOffset.value = globalIdLookupInfo.minSegId;
-        } else {
-          // the lut texture is spanning only the data range of the channel, not the datatype range
-          mat.uniforms.lutMinMax.value = new Vector2(channels[chIndex].rawMin, channels[chIndex].rawMax);
-          mat.uniforms.lutSampler.value = channels[chIndex].lutTexture;
+        const frame = channels[chIndex].frame;
+        let globalIdLookupInfo = feature.frameToGlobalIdLookup.get(frame);
+        if (!globalIdLookupInfo) {
+          console.warn(
+            `FusedChannelData.gpuFuse: No global ID lookup info for frame ${frame} in channel ${chIndex}. A default lookup will be used, which may cause visual artifacts.`
+          );
+          const texture = new DataTexture(new Uint32Array([0]), 1, 1, RedIntegerFormat, UnsignedIntType);
+          texture.needsUpdate = true;
+          globalIdLookupInfo = { texture, minSegId: 1 };
         }
-        this.fuseScene.add(new Mesh(this.fuseGeometry, mat));
+        mat.uniforms.segIdToGlobalId.value = globalIdLookupInfo.texture;
+        mat.uniforms.segIdOffset.value = globalIdLookupInfo.minSegId;
+      } else {
+        // the lut texture is spanning only the data range of the channel, not the datatype range
+        mat.uniforms.lutMinMax.value = new Vector2(channels[chIndex].rawMin, channels[chIndex].rawMax);
+        mat.uniforms.lutSampler.value = channels[chIndex].lutTexture;
       }
+      this.fuseScene.add(new Mesh(this.fuseGeometry, mat));
     }
     if (this.fuseScene.children.length > 0) {
       renderer.setRenderTarget(this.fuseRenderTarget);

--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -32,6 +32,19 @@ import fuseShaderSrcI from "./constants/shaders/fuseI.frag";
 import colorizeSrcUI from "./constants/shaders/colorizeUI.frag";
 import type { FuseChannel, NumberType } from "./types.js";
 
+// Immutable snapshot of the Channel fields needed by gpuFuse, captured at fuse() time.
+// Snapshot is required to avoid race conditions because Channels are mutable.
+type Fusable = FuseChannel & {
+  snapshot: {
+    dtype: NumberType;
+    dataTexture: DataTexture;
+    lutTexture: DataTexture;
+    rawMin: number;
+    rawMax: number;
+    frame: number;
+  };
+};
+
 // This is the owner of the fused RGBA volume texture atlas, and the mask texture atlas.
 // This module is responsible for updating the fused texture, given the read-only volume channel data.
 export default class FusedChannelData {
@@ -40,8 +53,7 @@ export default class FusedChannelData {
 
   public maskTexture: DataTexture;
 
-  private fuseRequested: FuseChannel[] | null;
-  private channelsDataToFuse: Channel[];
+  private fuseRequested: Fusable[] | null;
 
   private fuseGeometry: PlaneGeometry;
   private fuseMaterialF: ShaderMaterial;
@@ -75,7 +87,6 @@ export default class FusedChannelData {
     this.maskTexture.unpackAlignment = 1;
 
     this.fuseRequested = null;
-    this.channelsDataToFuse = [];
 
     this.fuseScene = new Scene();
     this.quadCamera = new OrthographicCamera(-1, 1, 1, -1, 0, 1);
@@ -207,10 +218,9 @@ export default class FusedChannelData {
   }
 
   fuse(combination: FuseChannel[], channels: Channel[]): void {
-    // Snapshot which channels are loaded and enabled right now,
-    // so gpuFuse() renders from this decision rather than re-reading
-    // mutable `channel.loaded` (which may be cleared by a concurrent load).
-    const readyToFuse: FuseChannel[] = [];
+    // Snapshot channel state now so gpuFuse() is immune to concurrent loads
+    // mutating the live Channel objects between fuse() and the next rAF.
+    const readyToFuse: Fusable[] = [];
     for (let i = 0; i < combination.length; ++i) {
       const c = combination[i];
       const idx = c.chIndex;
@@ -219,23 +229,30 @@ export default class FusedChannelData {
         // can optimize by calling combineLuts more lazily
         c.lut = channels[idx].combineLuts(c.rgbColor, c.lut);
         if (c.rgbColor) {
-          readyToFuse.push(c);
+          readyToFuse.push({
+            ...c,
+            snapshot: {
+              dtype: channels[idx].dtype,
+              dataTexture: channels[idx].dataTexture,
+              lutTexture: channels[idx].lutTexture,
+              rawMin: channels[idx].rawMin,
+              rawMax: channels[idx].rawMax,
+              frame: channels[idx].frame,
+            }
+          });
         }
       }
     }
     if (readyToFuse.length === 0) {
-      this.channelsDataToFuse = [];
       this.fuseRequested = null;
       return;
     }
 
     this.fuseRequested = readyToFuse;
-    this.channelsDataToFuse = channels;
   }
 
   public gpuFuse(renderer: WebGLRenderer): void {
     const combination = this.fuseRequested;
-    const channels = this.channelsDataToFuse;
     if (!combination) {
       return;
     }
@@ -252,11 +269,12 @@ export default class FusedChannelData {
     this.fuseScene.clear();
     for (let i = 0; i < combination.length; ++i) {
       const chIndex = combination[i].chIndex;
+      const snap = combination[i].snapshot;
       const isColorize = combination[i].feature !== undefined;
       // add a draw call per channel here.
       // must clone the material to keep a unique set of uniforms
-      const mat = this.getShader(channels[chIndex].dtype, isColorize).clone();
-      mat.uniforms.srcTexture.value = channels[chIndex].dataTexture;
+      const mat = this.getShader(snap.dtype, isColorize).clone();
+      mat.uniforms.srcTexture.value = snap.dataTexture;
       const feature = combination[i].feature;
       if (isColorize && feature) {
         mat.uniforms.featureData.value = feature.idsToFeatureValue;
@@ -273,11 +291,10 @@ export default class FusedChannelData {
         mat.uniforms.outOfRangeDrawMode.value = feature.outOfRangeDrawMode;
         mat.uniforms.hideOutOfRange.value = feature.hideOutOfRange;
 
-        const frame = channels[chIndex].frame;
-        let globalIdLookupInfo = feature.frameToGlobalIdLookup.get(frame);
+        let globalIdLookupInfo = feature.frameToGlobalIdLookup.get(snap.frame);
         if (!globalIdLookupInfo) {
           console.warn(
-            `FusedChannelData.gpuFuse: No global ID lookup info for frame ${frame} in channel ${chIndex}. A default lookup will be used, which may cause visual artifacts.`
+            `FusedChannelData.gpuFuse: No global ID lookup info for frame ${snap.frame} in channel ${chIndex}. A default lookup will be used, which may cause visual artifacts.`
           );
           const texture = new DataTexture(new Uint32Array([0]), 1, 1, RedIntegerFormat, UnsignedIntType);
           texture.needsUpdate = true;
@@ -287,8 +304,8 @@ export default class FusedChannelData {
         mat.uniforms.segIdOffset.value = globalIdLookupInfo.minSegId;
       } else {
         // the lut texture is spanning only the data range of the channel, not the datatype range
-        mat.uniforms.lutMinMax.value = new Vector2(channels[chIndex].rawMin, channels[chIndex].rawMax);
-        mat.uniforms.lutSampler.value = channels[chIndex].lutTexture;
+        mat.uniforms.lutMinMax.value = new Vector2(snap.rawMin, snap.rawMax);
+        mat.uniforms.lutSampler.value = snap.lutTexture;
       }
       this.fuseScene.add(new Mesh(this.fuseGeometry, mat));
     }

--- a/src/FusedChannelData.ts
+++ b/src/FusedChannelData.ts
@@ -32,8 +32,10 @@ import fuseShaderSrcI from "./constants/shaders/fuseI.frag";
 import colorizeSrcUI from "./constants/shaders/colorizeUI.frag";
 import type { FuseChannel, NumberType } from "./types.js";
 
-// Immutable snapshot of the Channel fields needed by gpuFuse, captured at fuse() time.
-// Snapshot is required to avoid race conditions because Channels are mutable.
+/**
+ * Immutable snapshot of the Channel fields needed by gpuFuse, captured at fuse() time.
+ * Snapshot is required to avoid race conditions because Channels are mutable.
+ */
 type Fusable = FuseChannel & {
   snapshot: {
     dtype: NumberType;
@@ -218,8 +220,11 @@ export default class FusedChannelData {
   }
 
   fuse(combination: FuseChannel[], channels: Channel[]): void {
-    // Snapshot channel state now so gpuFuse() is immune to concurrent loads
-    // mutating the live Channel objects between fuse() and the next rAF.
+    /**
+     * Snapshot channel state now so gpuFuse() is immune to concurrent loads
+     * mutating the live Channel objects between fuse() and the next
+     * requestAnimationFrame
+     */
     const readyToFuse: Fusable[] = [];
     for (let i = 0; i < combination.length; ++i) {
       const c = combination[i];


### PR DESCRIPTION
# Problem
Resolves #388 

# Root cause

`gpuFuse` references `Channels` fields, but those `Channels` are mutable, which allows the following race condition.

1. `fuse` for channel N checks that all `Channel.loaded` values are true and queues `gpuFuse` via `requestAnimationFrame`
2. `changeViewerSetting("time", N+1)` (vole-app) queues a react state update.
3. React update from 2 happens before the rAF from 1, triggering a `useEffect` in `vole-app`'s `App` that calls `setTime(view3d, N+1)`, which calls `vole-core`'s `Volume.setUnloaded`, updating the `Channel.loaded` values to false. 
4. rAF from 1 triggers `gpuFuse`, which checks `Channel.loaded`, sees false, and doesn't render the frame.

## Secondary bugs
The above is how the main bug works, but the fundamental issue is that mutable Channel fields can cause race conditions. There are a handful of those fields, beyond just `.loaded`. This PR should prevent all such bugs.

# Solution
* Remove the `Channel.loaded` check from `gpuFuse`.
* Instead of storing references to `Channel`s, `fuse` takes a snapshot of the channel data to fuse and puts it into a `Fusable` (better name, anyone?) which does not get modified. `gpuFuse` just reads from this `Fusable`.
* I also moved the `rgbColor` check (which I don't entirely understand) from `gpuFuse` to `fuse` so that all the logic about which channels to fuse is in one place.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to Verify:

See reproduction steps from #388.

## Performance

In my testing, this change gets us very roughly an extra 1-2FPS.