### PR TITLE
Throw more specific error when zarr buffer allocation fails

### DIFF
--- a/src/loaders/OmeZarrLoader.ts
+++ b/src/loaders/OmeZarrLoader.ts
@@ -565,15 +565,20 @@ class OMEZarrLoader extends ThreadableVolumeLoader {
       const sliceSpec = this.orderByDimension(unorderedSpec as TCZYX<number | zarr.Slice>, sourceIdx);
       const reportChunk = (coords: number[], sub: SubscriberId) => reportChunkBase(sourceIdx, coords, sub);
 
-      const result = await zarr
-        .get(level, sliceSpec, { opts: { subscriber, reportChunk } })
-        .catch(
-          wrapVolumeLoadError(
-            "Could not load OME-Zarr volume data",
-            VolumeLoadErrorType.LOAD_DATA_FAILED,
-            CHUNK_REQUEST_CANCEL_REASON
-          )
-        );
+      const result = await zarr.get(level, sliceSpec, { opts: { subscriber, reportChunk } }).catch((e) => {
+        if (e === CHUNK_REQUEST_CANCEL_REASON) {
+          return e;
+        }
+        if (e instanceof VolumeLoadError) {
+          throw e;
+        }
+        const msg =
+          e instanceof RangeError
+            ? "Could not allocate enough memory for the requested OME-Zarr data"
+            : "Could not load OME-Zarr volume data";
+        const type = e instanceof RangeError ? VolumeLoadErrorType.TOO_LARGE : VolumeLoadErrorType.LOAD_DATA_FAILED;
+        throw new VolumeLoadError(msg, { type, cause: e });
+      });
 
       if (result?.data === undefined) {
         return;


### PR DESCRIPTION
Review time: tiny (<5min)

`OMEZarrLoader` throws a slightly more specific error message when data loading fails while attempting to allocate an array buffer.
