### PR TITLE
refactor: Change `three` to a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@babel/runtime": "^7.25.6",
         "geotiff": "^2.0.5",
         "serialize-error": "^11.0.3",
-        "three": "^0.184.0",
         "throttled-queue": "^3.0.0",
         "tweakpane": "^3.1.9",
         "zarrita": "^0.5.1"
@@ -56,6 +55,9 @@
         "webpack": "^5.69.1",
         "webpack-cli": "^4.9.2",
         "webpack-dev-server": "^5.2.1"
+      },
+      "peerDependencies": {
+        "three": "^0.184.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -11345,7 +11347,8 @@
       "version": "0.184.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
       "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/throttled-queue": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,13 @@
     "type": "git",
     "url": "git+https://github.com/allen-cell-animated/vole-core.git"
   },
+  "peerDependencies": {
+    "three": "^0.184.0"
+  },
   "dependencies": {
     "@babel/runtime": "^7.25.6",
     "geotiff": "^2.0.5",
     "serialize-error": "^11.0.3",
-    "three": "^0.184.0",
     "throttled-queue": "^3.0.0",
     "tweakpane": "^3.1.9",
     "zarrita": "^0.5.1"


### PR DESCRIPTION
# Problem

I ran into a bug in TFE where 3D views would fail, but only in built files. I eventually traced this to changes made in #395, and discovered that it was caused by having conflicting versions of three installed in TFE vs. `vole-core`.

Changing `three` to a peer dependency in `vole-core` would help prevent this in the future, so that client libraries only have one version of `three` installed. 

Couple questions:
- Should we set a maximum upper bound for what version of `three` we support, in case there are breaking changes on a minor version in the future?