### PR TITLE
Fix dimension ordering for out-of-order dimensions

### DIFF
--- a/src/loaders/VolumeLoaderUtils.ts
+++ b/src/loaders/VolumeLoaderUtils.ts
@@ -209,7 +209,7 @@ export function composeSubregion(region: Box3, container: Box3): Box3 {
   return new Box3(min, max);
 }
 
-function isEmpty(obj) {
+function isEmpty(obj: object) {
   for (const key in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {
       return false;

--- a/src/loaders/zarr_utils/utils.ts
+++ b/src/loaders/zarr_utils/utils.ts
@@ -82,19 +82,26 @@ export function remapAxesToTCZYX(axes: OMEAxis[]): TCZYX<number> {
   return axesTCZYX;
 }
 
-/** Reorder an array of values [T, C, Z, Y, X] to the given dimension order */
-export function orderByDimension<T>(valsTCZYX: TCZYX<T>, orderTCZYX: TCZYX<number>): T[] {
+/**
+ * Reorder an array of `values` in TCZYX order to the dimension order specified by `orderTCZYX`.
+ *
+ * Each element of `orderTCZYX` is the index of each dimension in its volume's native dimension
+ * order, or `-1` if the volume does not contain that dimension. For example, the array
+ * `[-1, 1, 0, 2, 3]` represents ZCYX order: T not present; C at index `1`; Z at index `0`; Y at
+ * index `2`; X at index `3`.
+ */
+export function orderByDimension<T>(values: TCZYX<T>, orderTCZYX: TCZYX<number>): T[] {
   const specLen = getDimensionCount(orderTCZYX);
   const result: T[] = Array(specLen);
 
-  orderTCZYX.forEach((val, idx) => {
-    if (val >= 0) {
-      if (val >= specLen) {
-        throw new VolumeLoadError(`Unexpected axis index in zarr: ${val}`, {
+  orderTCZYX.forEach((dimIndex, tczyxIndex) => {
+    if (dimIndex >= 0) {
+      if (dimIndex >= specLen) {
+        throw new VolumeLoadError(`Unexpected axis index in zarr: ${dimIndex}`, {
           type: VolumeLoadErrorType.INVALID_METADATA,
         });
       }
-      result[val] = valsTCZYX[idx];
+      result[dimIndex] = values[tczyxIndex];
     }
   });
 

--- a/src/loaders/zarr_utils/utils.ts
+++ b/src/loaders/zarr_utils/utils.ts
@@ -87,7 +87,6 @@ export function orderByDimension<T>(valsTCZYX: TCZYX<T>, orderTCZYX: TCZYX<numbe
   const specLen = getDimensionCount(orderTCZYX);
   const result: T[] = Array(specLen);
 
-  let curIdx = 0;
   orderTCZYX.forEach((val, idx) => {
     if (val >= 0) {
       if (val >= specLen) {
@@ -95,7 +94,7 @@ export function orderByDimension<T>(valsTCZYX: TCZYX<T>, orderTCZYX: TCZYX<numbe
           type: VolumeLoadErrorType.INVALID_METADATA,
         });
       }
-      result[curIdx++] = valsTCZYX[idx];
+      result[val] = valsTCZYX[idx];
     }
   });
 

--- a/src/test/zarr_utils.test.ts
+++ b/src/test/zarr_utils.test.ts
@@ -224,17 +224,17 @@ describe("zarr_utils", () => {
   });
   // TODO: `pickLevelToLoad`
 
-  const VALS_TCZYX: TCZYX<number> = [1, 2, 3, 4, 5];
+  const VALS_TCZYX: TCZYX<string> = ["t", "c", "z", "y", "x"];
   describe("orderByDimension", () => {
     it("orders an array in dimension order based on the given indices", () => {
       const order: TCZYX<number> = [3, 1, 4, 0, 2];
-      expect(orderByDimension(VALS_TCZYX, order)).to.deep.equal([4, 2, 5, 1, 3]);
+      expect(orderByDimension(VALS_TCZYX, order)).to.deep.equal(["y", "c", "x", "t", "z"]);
     });
 
     it("excludes the T, C, or Z dimension if its index is negative", () => {
-      expect(orderByDimension(VALS_TCZYX, [-1, 0, 1, 3, 2])).to.deep.equal([2, 3, 5, 4]);
-      expect(orderByDimension(VALS_TCZYX, [0, -1, 1, 3, 2])).to.deep.equal([1, 3, 5, 4]);
-      expect(orderByDimension(VALS_TCZYX, [0, 1, -1, 3, 2])).to.deep.equal([1, 2, 5, 4]);
+      expect(orderByDimension(VALS_TCZYX, [-1, 0, 1, 3, 2])).to.deep.equal(["c", "z", "x", "y"]);
+      expect(orderByDimension(VALS_TCZYX, [0, -1, 1, 3, 2])).to.deep.equal(["t", "z", "x", "y"]);
+      expect(orderByDimension(VALS_TCZYX, [0, 1, -1, 3, 2])).to.deep.equal(["t", "c", "x", "y"]);
     });
 
     it("throws an error if an axis index is out of bounds", () => {

--- a/src/test/zarr_utils.test.ts
+++ b/src/test/zarr_utils.test.ts
@@ -228,13 +228,13 @@ describe("zarr_utils", () => {
   describe("orderByDimension", () => {
     it("orders an array in dimension order based on the given indices", () => {
       const order: TCZYX<number> = [3, 1, 4, 0, 2];
-      expect(orderByDimension(VALS_TCZYX, order)).to.deep.equal([1, 2, 3, 4, 5]);
+      expect(orderByDimension(VALS_TCZYX, order)).to.deep.equal([4, 2, 5, 1, 3]);
     });
 
     it("excludes the T, C, or Z dimension if its index is negative", () => {
-      expect(orderByDimension(VALS_TCZYX, [-1, 0, 1, 3, 2])).to.deep.equal([2, 3, 4, 5]);
-      expect(orderByDimension(VALS_TCZYX, [0, -1, 1, 3, 2])).to.deep.equal([1, 3, 4, 5]);
-      expect(orderByDimension(VALS_TCZYX, [0, 1, -1, 3, 2])).to.deep.equal([1, 2, 4, 5]);
+      expect(orderByDimension(VALS_TCZYX, [-1, 0, 1, 3, 2])).to.deep.equal([2, 3, 5, 4]);
+      expect(orderByDimension(VALS_TCZYX, [0, -1, 1, 3, 2])).to.deep.equal([1, 3, 5, 4]);
+      expect(orderByDimension(VALS_TCZYX, [0, 1, -1, 3, 2])).to.deep.equal([1, 2, 5, 4]);
     });
 
     it("throws an error if an axis index is out of bounds", () => {


### PR DESCRIPTION
Review time: tiny (<5min)

# Problem

Certain OME-Zarr images with nonstandard dimension ordering (ZCYX) were not being assembled correctly.

# Solution

The OME-Zarr utility function `orderByDimension` correctly handled *missing* dimensions, but would not reorder dimensions in nonstandard order. A small tweak solved this.
