### PR TITLE
Remote typeRoots to support npm workspace install

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
     "sourceMap": true,
     "strict": true,
     "target": "ES6",
-    "typeRoots": ["src/types", "node_modules"],
     "types": ["vitest/globals"]
   },
   "files": ["src/index.ts", "public/index.ts"],


### PR DESCRIPTION
# Context

For my local development, I have `vole-app` and `vole-core` installed as sibling npm workspaces, with the following structure. This is convenient because it removes the need to manually manage `npm link` when working on both repos at once.

```
.
├── package.json
├── vole-app
└── vole-core
```

The top-level `package.json` is just this (the three.js lines are for working around the [issue addressed here](https://github.com/allen-cell-animated/vole-app/pull/541)):

```
{
  "private": true,
  "workspaces": [
    "vole-app",
    "vole-core"
  ],
  "devDependencies": {
    "three": "0.184.0",
    "@types/three": "0.184.0"
  }
}
```

# Problem

An `npm install` (which triggers `npm install` from both repos) fails during `@aics/vole-core@4.9.2 build-types` with `error TS2688: Cannot find type definition file for 'vitest/globals'.` This happens because in the workspace setup, there is a single `node_modules` folder is at the top level, not inside `vole-core` (or `vole-app`).

# Solution

Remove the `typeRoots` line that prevents `tsc` from looking at the top level `node_modules`. This change should only expand the number of places that `tsc` looks for the `vitest` type definition.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Steps to Verify:
To confirm this change doesn't break anything, do a `git clean` to remove compiled type information, then an `npm i & npm run build`.

To confirm the change fixes the issue:
```
mkdir test
cd test

git clone git@github.com:allen-cell-animated/vole-core.git vole-core
git clone git@github.com:allen-cell-animated/vole-app.git vole-app
vim package.json
npm i
```
