### PR TITLE
Bugfix/backticks in glsl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "typescript-eslint": "^8.58.2",
         "url-loader": "^4.1.1",
         "vite": "^8.1.0",
-        "vite-plugin-glsl": "^1.3.1",
         "vitest": "^4.1.9",
         "webpack": "^5.69.1",
         "webpack-cli": "^4.9.2",
@@ -1467,9 +1466,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1487,9 +1483,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1507,9 +1500,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1527,9 +1517,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1547,9 +1534,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1567,9 +1551,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7339,9 +7320,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7363,9 +7341,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7387,9 +7362,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7411,9 +7383,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12261,30 +12230,6 @@
           "optional": true
         },
         "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-plugin-glsl": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-glsl/-/vite-plugin-glsl-1.6.0.tgz",
-      "integrity": "sha512-3i3ZvIVb13LhTcAXEHGTOW+cNG2jbJ++XsDFyCWUpnoFN1NPXvdtC4j66pig+i0QjDnmusOK/YCpiDWizxBY0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.17.0",
-        "npm": ">= 10.8.3"
-      },
-      "peerDependencies": {
-        "@rollup/pluginutils": "^5.x",
-        "esbuild": ">= 0.25",
-        "vite": ">= 3.x"
-      },
-      "peerDependenciesMeta": {
-        "@rollup/pluginutils": {
-          "optional": true
-        },
-        "esbuild": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "typescript-eslint": "^8.58.2",
     "url-loader": "^4.1.1",
     "vite": "^8.1.0",
-    "vite-plugin-glsl": "^1.3.1",
     "vitest": "^4.1.9",
     "webpack": "^5.69.1",
     "webpack-cli": "^4.9.2",

--- a/vite.config.test.ts
+++ b/vite.config.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { glslTransform } from "./vite.config.js";
+
+describe("GLSL transform", () => {
+  it("escapes special characters (e.g. backticks) so they aren't interpreted as JS", () => {
+    // Arrange
+    const code = "`backtick`, \\ and ${notATemplateExpression}";
+    
+    // Act
+    const result = glslTransform(code, "shader.frag");
+    const body = (result || "").replace("export default", "return");
+    const evaluated = new Function(body)();
+
+    // Assert
+    expect(evaluated).to.equal(code);
+  });
+});

--- a/vite.config.test.ts
+++ b/vite.config.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 
 import { glslTransform } from "./vite.config.js";
+import fs from 'fs';
 
 describe("GLSL transform", () => {
-  it("escapes special characters (e.g. backticks) so they aren't interpreted as JS", () => {
+  const dir = './src/constants/shaders/';
+  const files = fs.readdirSync(dir).map(file => dir + file);
+
+  it.each(files)("escapes special characters in %s", (file) => {
     // Arrange
-    const code = "`backtick`, \\ and ${notATemplateExpression}";
+    const code = fs.readFileSync(file).toString();
     
     // Act
     const result = glslTransform(code, "shader.frag");

--- a/vite.config.test.ts
+++ b/vite.config.test.ts
@@ -9,7 +9,7 @@ describe("GLSL transform", () => {
     
     // Act
     const result = glslTransform(code, "shader.frag");
-    const body = (result || "").replace("export default", "return");
+    const body = (result ?? "").replace("export default", "return");
     const evaluated = new Function(body)();
 
     // Assert

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,16 @@
 import type { UserConfig } from "vite";
 
+export function glslTransform(code, id) {
+    // For glsl file extensions, resolve `import foo from "./bar.frag"` to
+    // the plain text source code of bar.frag.
+    // JSON.stringify is required to escape special characters: backticks
+    // in `code` would otherwise be interpreted as Javascript.
+    // Unit test in vite.config.test.ts checks this.
+    if (/\.(glsl|frag|vert|fs|vs)$/.test(id)) {
+      return `export default ${JSON.stringify(code)};`;
+    }
+}
+
 // We want to be able to import glsl shaders without url decorations like ?raw.
 // This is because we still build the distribution with babel/tsc and don't want
 // to use nonstandard import syntax there.
@@ -7,11 +18,7 @@ export default {
   plugins: [
     {
       name: "raw-shaders",
-      // For glsl file extensions, resolve `import foo from "./bar.frag"` to the plain text source code of bar.frag
-      // JSON.stringify is required to escape special characters: backticks in `code` would otherwise be interpreted
-      // as Javascript.
-      transform: (code, id) =>
-        /\.(glsl|frag|vert|fs|vs)$/.test(id) ? `export default ${JSON.stringify(code)};` : undefined,
+      transform: glslTransform,
     },
   ],
   define: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,10 +3,17 @@ import type { UserConfig } from "vite";
 // We want to be able to import glsl shaders without url decorations like ?raw.
 // This is because we still build the distribution with babel/tsc and don't want
 // to use nonstandard import syntax there.
-import glsl from "vite-plugin-glsl";
-
 export default {
-  plugins: [glsl()],
+  plugins: [
+    {
+      name: "raw-shaders",
+      // For glsl file extensions, resolve `import foo from "./bar.frag"` to the plain text source code of bar.frag
+      // JSON.stringify is required to escape special characters: backticks in `code` would otherwise be interpreted
+      // as Javascript.
+      transform: (code, id) =>
+        /\.(glsl|frag|vert|fs|vs)$/.test(id) ? `export default ${JSON.stringify(code)};` : undefined,
+    },
+  ],
   define: {
     APP_VERSION: JSON.stringify(process.env.npm_package_version),
   },


### PR DESCRIPTION
# Problem
* Backticks in glsl code trigger bugs in vite-plugin-glsl
  *  This already has a workaround [here](https://github.com/allen-cell-animated/vole-core/pull/392/changes#diff-feea930451be62e0d340bd6b10ac8c97cd4b5c542c9222e4b72ebdcc05bdbd5f) and will soon be fixed upstream
* But in addition, vite-plugin-glsl has a lot of logic (implementing #import for glsl, minifying glsl) compared to what vole-core actually needs: importing glsl without the `?raw` suffix.

# Solution

Write a tiny plugin that interprets `.glsl`, `.frag`, `.vert`, `.fs`, and `.vs` files as raw strings.

## Type of change

- Bug fix

## Testing
- Confirmed that unit test fails if the transform does ``return `${code}`;``
- New unit test passes
- Demo app renders Time Series Json nicely