### PR TITLE
Fix matchSourceScaleLevels edge case

### DIFF
--- a/src/loaders/zarr_utils/utils.ts
+++ b/src/loaders/zarr_utils/utils.ts
@@ -278,7 +278,7 @@ export function matchSourceScaleLevels(sources: ZarrSource[]): void {
     }
   }
 
-  if (sources[0].scaleLevels.length === 0) {
+  if (matchedLevels[0].length === 0) {
     throw new VolumeLoadError("Incompatible zarr arrays: no sets of scale levels found that matched in all sources", {
       type: VolumeLoadErrorType.INVALID_MULTI_SOURCE_ZARR,
     });

--- a/src/test/zarr_utils.test.ts
+++ b/src/test/zarr_utils.test.ts
@@ -384,6 +384,27 @@ describe("zarr_utils", () => {
       );
     });
 
+    it("throws an error if sources have no matching scale levels", async () => {
+      const sources = await createMockSources([
+        {
+          shapes: [
+            [1, 1, 10, 10, 10],
+            [1, 1, 5, 5, 5],
+          ],
+        },
+        {
+          shapes: [
+            [1, 1, 8, 8, 8],
+            [1, 1, 4, 4, 4],
+          ],
+        },
+      ]);
+
+      expect(() => matchSourceScaleLevels(sources)).to.throw(
+        "Incompatible zarr arrays: no sets of scale levels found that matched in all sources"
+      );
+    });
+
     it("Does not throw an error if two scale levels of the same size have different scale transformations", async () => {
       const sources = await createMockSources([
         { shapes: [[1, 1, 1, 1, 1]], scales: [[1, 1, 2, 2, 2]] },


### PR DESCRIPTION
# Problem

Explanation in #443 

See regression test in this PR for a clear example.

# Solution
`matchSourceScaleLevels` checks `matchedLevels[0]` (which has scale levels that match across sources) instead of `sources[0].scaleLevels` (which isn't updated until after line 281).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Steps to Verify:

1. Confirm that the regression test has the right behavior
2. Regression test fails without the fix
3. Regression test passes now